### PR TITLE
Refinement of SQLAlchemy v1/2 handling

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,6 +73,13 @@ jobs:
         shell: bash
         run: nox --force-color -s tests-${{ matrix.python-version }}
 
+      - name: Run SQLAlchemy backwards compatibility check
+        if: matrix.os == 'Ubuntu'
+        shell: bash
+        env:
+          SQLALCHEMY_VERSION: '==1.4.16'  # Minimal version for Pandas
+        run: nox --force-color -s tests-${{ matrix.python-version }}
+
       - name: Run safety check
         if: matrix.python-version == '3.10' && matrix.os == 'Ubuntu'
         shell: bash

--- a/mypy.ini
+++ b/mypy.ini
@@ -30,6 +30,3 @@ warn_unreachable = true
 
 [mypy-pandas.*]
 ignore_missing_imports = True
-
-[mypy-sqlalchemy.*]
-ignore_missing_imports = True

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,4 +1,5 @@
 """Nox sessions."""
+import os
 import platform
 import tempfile
 from typing import Any
@@ -35,6 +36,10 @@ def install_with_constraints(session: Session, *args: str, **kwargs: Any) -> Non
             external=True,
         )
         session.install("-r", requirements.name, *args, **kwargs)
+
+    sqlalchemy_version = os.environ.get("SQLALCHEMY_VERSION")
+    if sqlalchemy_version:
+        session.install(f"sqlalchemy{sqlalchemy_version}")
 
 
 def install_with_project_extras(session: Session) -> None:

--- a/poetry.lock
+++ b/poetry.lock
@@ -4054,4 +4054,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "<4,>=3.8"
-content-hash = "6fb4afaa6cdaee692cc640f6251f13f9e1d2e84f1a7af92d3e334f80de18b0aa"
+content-hash = "cc9abee99d6860cf5a388814c837edaa8b7f959c75e5a900258cd6b2da7634d1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 python = "<4,>=3.8"
 
 pandas = ">=1.1"
-sqlalchemy = ">2"
+sqlalchemy = ">=1.4"
 tomli = { version = ">=2.0.1", markers = "python_version < '3.11'" }
 rics = ">=2"
 
@@ -101,6 +101,7 @@ pre-commit = "^2.20.0"
 invoke = ">=2.0.0"
 safety = "^2.1.1"
 mypy = "^0.991"
+sqlalchemy = ">2"
 bump2version = "^1.0.1"
 
 [tool.flakeheaven]

--- a/src/id_translation/fetching/_sql_fetcher.py
+++ b/src/id_translation/fetching/_sql_fetcher.py
@@ -119,8 +119,11 @@ class SqlFetcher(AbstractFetcher[str, IdType]):
         return PlaceholderTranslations(instr.source, tuple(columns), records)
 
     def _make_query(
-        self, ts: "SqlFetcher.TableSummary", select: sqlalchemy.sql.Select[Any], ids: Set[IdType]
-    ) -> sqlalchemy.sql.Select[Any]:
+        self,
+        ts: "SqlFetcher.TableSummary",
+        select: sqlalchemy.sql.Select,  # type: ignore[type-arg]
+        ids: Set[IdType],
+    ) -> sqlalchemy.sql.Select:  # type: ignore[type-arg]
         where = self.selection_filter_type(ids, ts, **self._select_params)
 
         if where == "in":
@@ -247,7 +250,9 @@ class SqlFetcher(AbstractFetcher[str, IdType]):
         return ans
 
     def make_table_summary(
-        self, table: sqlalchemy.sql.schema.Table, id_column: sqlalchemy.sql.schema.Column[Any]
+        self,
+        table: sqlalchemy.sql.schema.Table,
+        id_column: sqlalchemy.sql.schema.Column,  # type: ignore[type-arg]
     ) -> "SqlFetcher.TableSummary":
         """Create a table summary."""
         start = perf_counter()
@@ -260,7 +265,7 @@ class SqlFetcher(AbstractFetcher[str, IdType]):
     def get_approximate_table_size(
         self,
         table: sqlalchemy.sql.schema.Table,
-        id_column: sqlalchemy.sql.schema.Column[Any],
+        id_column: sqlalchemy.sql.schema.Column,  # type: ignore[type-arg]
     ) -> int:
         """Return the approximate size of a table.
 
@@ -351,11 +356,11 @@ class SqlFetcher(AbstractFetcher[str, IdType]):
         """Name of the table."""
         size: int
         """Approximate size of the table."""
-        columns: sqlalchemy.sql.base.ColumnCollection[str, Any]
+        columns: sqlalchemy.sql.base.ColumnCollection  # type: ignore[type-arg]
         """A flag indicating that the FETCH_ALL-operation is permitted for this table."""
         fetch_all_permitted: bool
         """A flag indicating that the FETCH_ALL-operation is permitted for this table."""
-        id_column: sqlalchemy.schema.Column[Any]
+        id_column: sqlalchemy.schema.Column  # type: ignore[type-arg]
         """The ID column of the table."""
 
         def select_columns(self, instr: FetchInstruction[str, IdType]) -> List[str]:


### PR DESCRIPTION
Refinement of SQLAlchemy v1/2 handling

- Run unit tests for SQLAlchemy==1.4.0 for matrix.os == 'Ubuntu'
- Remove generic type args for SQLAlchemy types
  These were just set to Any. Adding ignore[type-arg] has more or less the
  same effect.
- Require SQLAlchemy >=1.4 rather than 2.0
  No 2.0 features were used (except generic typehints, see above). Added
  SQLAlchemy>2 as a dev dependency.