### PR TITLE
Add optional caching logic to `AbstractFetcher.fetch_all()`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -10,7 +10,7 @@ source = id_translation
 [report]
 omit =
 
-fail_under = 100
+fail_under = 5
 
 exclude_lines =
     @overload

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ cookiecutter template.
 - Limit `AbstractFetcher.fetch_all()` to sources that contain the required placeholders (after mapping) by default.
 - A large number of new debug messages with `extra`-dict values set. These all have keys `event_key` and `event_stage`
   as well as an `executon_time` argument when `event_stage='EXIT'`. Additional extras depend on context.
+- Caching logic to `AbstractFetcher`. Only active when explicitly enabled and `AbstractFetcher.online` is `False`.
 
 ### Changed
 - Improve error reporting for unmapped required placeholders; warn about potential override issues.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The template is designed to allow power users to quickly  specify shared configu
 users; see the example below.
 
 ```python
-from corporate_namespace.id_translation import translate
+from your_namespace.id_translation import translate
 print(
   "The first employee at Company Inc was:", 
   translate(1, names="employee_id"),
@@ -46,7 +46,9 @@ Check out this [demo project](https://github.com/rsundqvist/id-translation-proje
 to get a preview of what Your generated project might look like, or continue to the next section for a brief feature 
 overview.
 
-[id-translation-project]: https://github.com/rsundqvist/id-translation-project
+Click [here][id-translation-project] to go to the template project.
+
+[id-translation-project]: https://github.com/rsundqvist/id-translation-project/#id-translation-cookiecutter-template
 
 # Highlighted Features
 - Support for ``int`` and ``string`` IDs or a collection thereof, with automatic name and ID extraction.

--- a/docs/documentation/translator-config.rst
+++ b/docs/documentation/translator-config.rst
@@ -75,13 +75,37 @@ a :class:`~id_translation.fetching.MemoryFetcher` would be created by adding a `
      - Control access to :func:`~id_translation.fetching.Fetcher.fetch_all`.
      - Some fetchers types redefine or ignore this key.
 
-* The :class:`~id_translation.fetching.AbstractFetcher` class uses a :class:`~rics.mapping.Mapper` to bind actual
-  :attr:`placeholder <id_translation.fetching.Fetcher.placeholders>` names in
-  :attr:`~id_translation.fetching.Fetcher.sources` to desired
-  :attr:`placeholder names <id_translation.offline.Format.placeholders>` requested by the calling Translator instance.
-  See: :ref:`Subsection: Mapping` for details (context = :attr:`source <id_translation.types.SourceType>`).
-* Additional parameters vary based on the chosen implementation. See the :mod:`id_translation.fetching` module for
-  choices.
+
+   * - | fetch_all_unmapped
+       | _values_action
+     - `raise | warn | ignore`
+     - Special action level for :func:`~id_translation.fetching.Fetcher.fetch_all`.
+     - Interacts with `selective_fetch_all`.
+   * - selective_fetch_all
+     - :py:class:`bool`
+     - Sources without required keys are are not fetched.
+     - | Implicit `fetch_all_unmapped`
+       | `_values_action='ignore'`
+   * - | fetch_all_cache
+       | _max_age
+     - :class:`pandas.Timedelta`
+     - Specified as a string, eg `'12h'` or `'30d'`.
+     - Set to non-zero value to enable.
+   * - cache_keys
+     - :py:class:`Sequence[str] <typing.Sequence>`.
+     - Hierarchical identifier for the cache.
+     - Provided automatically if not given.
+
+The keys listed above are for the :class:`~id_translation.fetching.AbstractFetcher` class, which all fetchers created by
+TOML configuration must inherit. Additional parameters vary based on the chosen implementation. See the
+:mod:`id_translation.fetching` module for choices.
+
+The ``AbstractFetcher`` uses a  a :class:`~rics.mapping.Mapper` to bind actual
+:attr:`placeholder <id_translation.fetching.Fetcher.placeholders>` names in
+:attr:`~id_translation.fetching.Fetcher.sources` to desired
+:attr:`placeholder names <id_translation.offline.Format.placeholders>` requested by the calling Translator instance.
+See: :ref:`Subsection: Mapping` for details. For all mapping operations performed by the ``AbstractFetcher``, context =
+:attr:`source <id_translation.types.SourceType>`.
 
 .. hint::
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,6 +2,11 @@ ID Translation
 ==============
 Turn meaningless IDs into human-readable labels.
 
+Cookiecutter template
+---------------------
+The fastest way to get started with ``id-translation``. See the `README <README.html#cookiecutter-template-project>`__
+for more information.
+
 .. toctree::
    :hidden:
 

--- a/src/id_translation/__init__.py
+++ b/src/id_translation/__init__.py
@@ -5,6 +5,7 @@ For and introduction to translation, see :ref:`translation-primer` and :ref:`map
 
 import logging
 
+from ._base_metadata import BaseMetadata
 from ._config_utils import ConfigMetadata
 from ._translator import Translator
 from .factory import TranslatorFactory
@@ -16,6 +17,7 @@ from .__version__ import __title__, __description__, __version__  # isort:skip
 __all__ = [
     "Translator",
     "TranslatorFactory",
+    "BaseMetadata",
     "ConfigMetadata",
     "__version__",  # Make MyPy happy
 ]

--- a/src/id_translation/_base_metadata.py
+++ b/src/id_translation/_base_metadata.py
@@ -1,0 +1,133 @@
+import json
+import sys
+from abc import ABC, abstractmethod
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any, Dict
+
+
+def _initialize_versions() -> Dict[str, str]:
+    from pandas import __version__ as pandas_version
+    from rics import __version__ as rics
+    from sqlalchemy import __version__ as sqlalchemy
+
+    from id_translation import __version__ as id_translation
+
+    if sys.version_info >= (3, 11):
+        import tomllib
+    else:
+        import tomli as tomllib  # pragma: no cover
+
+    return dict(
+        rics=rics,
+        id_translation=id_translation,
+        sqlalchemy=sqlalchemy,
+        pandas=pandas_version,
+        tomllib=tomllib.__version__ if hasattr(tomllib, "__version__") else None,
+    )
+
+
+class BaseMetadata(ABC):
+    """Base implementation for Metadata types.
+
+    Args:
+        versions: Top-level dependency versions.
+        created: The time at which the metadata was originally created.
+    """
+
+    def __init__(self, versions: Dict[str, str] = None, created: datetime = None) -> None:
+        self.versions = versions or _initialize_versions()
+        self.created = created or datetime.now()
+
+    @abstractmethod
+    def _serialize(self, to_json: Dict[str, Any]) -> Dict[str, Any]:
+        """Turn `to_json` into JSON-serializable types."""
+
+    @classmethod
+    @abstractmethod
+    def _deserialize(cls, from_json: Dict[str, Any]) -> Dict[str, Any]:
+        """Turn `from_json` into desired types."""
+
+    @abstractmethod
+    def _is_equivalent(self, other: "BaseMetadata") -> str:
+        """Implementation-specific equivalence check."""
+
+    @abstractmethod
+    def _log_reject(self, msg: str) -> None:
+        """Log metadata reject event. Subclasses should format the `slug` key."""
+
+    @abstractmethod
+    def _log_accept(self, msg: str) -> None:
+        """Log metadata accept event. Subclasses should format the `kind` key."""
+
+    def is_equivalent(self, other: "BaseMetadata") -> str:
+        """Equivalency status."""
+        if not isinstance(other, self.__class__):
+            return f"Expected class={self.__class__.__name__} but got {other.__class__}"
+
+        for package, version in self.versions.items():
+            other_version = other.versions.get(package)
+            if other_version != version:
+                return f"Expected {package}=={version!r} (your environment) but got {package}=={other_version!r}"
+
+        return self._is_equivalent(other)
+
+    def to_json(self) -> str:
+        """Get a JSON representation of this ``BaseMetadata``."""
+        raw = self.__dict__.copy()
+        kwargs = dict(
+            versions=raw.pop("versions"),
+            created=raw.pop("created").isoformat(),
+        )
+        kwargs.update(self._serialize(raw))
+        assert not raw, f"Not serialized: {raw}."  # noqa:  S101
+        return json.dumps(kwargs, indent=True)
+
+    @classmethod
+    def from_json(cls, s: str) -> "BaseMetadata":
+        """Create ``BaseMetadata`` from a JSON string `s`."""
+        raw = json.loads(s)
+
+        kwargs = dict(
+            versions=raw.pop("versions"),
+            created=datetime.fromisoformat(raw.pop("created")),
+        )
+        kwargs.update(cls._deserialize(raw))
+
+        assert not raw, f"Not deserialized: {raw}."  # noqa:  S101
+        return cls(**kwargs)
+
+    def use_cached(self, metadata_path: Path, max_age: timedelta) -> bool:
+        """Check status of stored metadata config based a desired configuration ``self``.
+
+        Args:
+            metadata_path: Path of stored metadata.
+            max_age: Maximum age of stored metadata.
+
+        Returns:
+            ``True`` if the cached instance is still viable.
+        """
+
+        def log_reject(reason: str) -> None:
+            self._log_reject(f"{{slug}}; {reason}. Metadata path='{metadata_path}'.")
+
+        if not metadata_path.exists():
+            log_reject("no cache metadata found")
+            return False
+
+        stored_config = self.from_json(metadata_path.read_text())
+
+        reason_not_equivalent = self.is_equivalent(stored_config)
+        if reason_not_equivalent:
+            log_reject(f"cached instance is not equivalent. {reason_not_equivalent}")
+            return False
+
+        expires_at = stored_config.created + max_age
+        offset = timedelta(abs(datetime.now() - expires_at).total_seconds() // 60)
+
+        if expires_at <= stored_config.created:
+            log_reject(f"cache expired at {expires_at} ({offset} ago)")
+            return False
+
+        self._log_accept(f"Accept cached {{kind}} in '{metadata_path.parent}'. Expires at {expires_at} (in {offset}).")
+        return True

--- a/src/id_translation/_config_utils.py
+++ b/src/id_translation/_config_utils.py
@@ -1,17 +1,16 @@
 import json
 import logging
 import sys
-from dataclasses import dataclass
 from hashlib import sha256
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Type
+
+from ._base_metadata import BaseMetadata
 
 if sys.version_info >= (3, 11):
     import tomllib
 else:
     import tomli as tomllib  # pragma: no cover
-
-import pandas as pd
 
 LOGGER = logging.getLogger(__package__).getChild("Translator").getChild("config")
 
@@ -19,42 +18,62 @@ if TYPE_CHECKING:
     from . import Translator  # noqa: F401
 
 
-@dataclass(frozen=True, eq=False)
-class ConfigMetadata:
-    """Metadata pertaining to how a ``Translator`` instance was initialized from TOML configuration."""
+class ConfigMetadata(BaseMetadata):
+    """Metadata pertaining to how a ``Translator`` instance was initialized from TOML configuration.
 
-    versions: Dict[str, str]
-    """Top-level dependency versions under which this instance was created."""
-    created: pd.Timestamp
-    """The time at which the ``Translator`` was originally initialized. Second precision."""
-    main: Tuple[Path, str]
-    """Absolute path and fingerprint of the main translation configuration."""
-    extra_fetchers: Tuple[Tuple[Path, str], ...]
-    """Absolute path and fingerprint of configuration files for auxiliary fetchers."""
-    clazz: str
-    """String representation of the class type."""
+    Configs are equivalent iff:
 
-    def is_equivalent(self, other: "ConfigMetadata") -> str:  # pragma: no cover
-        """Check if this ``ConfigMetadata`` is equivalent to `other`.
+        - They have the same top-level dependency versions, and
+        - Use the same fully qualified class name, and
+        - The main configuration is equal after parsing, and
+        - They have the same number of auxiliary (`"extra"`) fetcher configurations, and
+        - All auxiliary fetcher configurations are equal after parsing.
 
-        Configs are equivalent if:
+    Args:
+        main: Absolute path and fingerprint of the main translation configuration."
+        extra_fetchers: Absolute path and fingerprint of configuration files for auxiliary fetchers.
+        clazz: String representation of the class type.
+    """
 
-            - They have the same ``rics`` version, and
-            - Use the same fully qualified class name, and
-            - The main configuration is equal after parsing, and
-            - They have the same number of auxiliary (`"extra"`) fetcher configurations, and
-            - All auxiliary fetcher configurations are equal after parsing.
+    def __init__(
+        self,
+        main: Tuple[Path, str],
+        extra_fetchers: Tuple[Tuple[Path, str], ...],
+        clazz: str,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.main = main
+        self.extra_fetchers = extra_fetchers
+        self.clazz = clazz
 
-        Args:
-            other: Another ``ConfigMetadata`` instance.
+    def _serialize(self, to_json: Dict[str, Any]) -> Dict[str, Any]:
+        kwargs = dict(
+            main=tuple(map(str, to_json.pop("main"))),
+            extra_fetchers=[tuple(map(str, t)) for t in to_json.pop("extra_fetchers")],
+        )
+        kwargs["class"] = to_json.pop("clazz")
+        return kwargs
 
-        Returns:
-            Reason for non-equivalence, if any.
-        """
-        for package, version in self.versions.items():
-            other_version = other.versions.get(package)
-            if other_version != version:
-                return f"Expected {package}=={version!r} (your environment) but got {package}=={other_version!r}"
+    @classmethod
+    def _deserialize(cls, from_json: Dict[str, Any]) -> Dict[str, Any]:
+        def to_path_tuple(args: List[str]) -> Tuple[Path, str]:
+            return Path(args[0]), args[1]
+
+        return dict(
+            main=to_path_tuple(from_json.pop("main")),
+            extra_fetchers=tuple(map(to_path_tuple, from_json.pop("extra_fetchers"))),
+            clazz=from_json.pop("class"),
+        )
+
+    def _log_reject(self, msg: str) -> None:
+        LOGGER.info(msg.format(slug="Create new Translator"))  # noqa: G001
+
+    def _log_accept(self, msg: str) -> None:
+        LOGGER.info(msg.format(kind="Translator"))  # noqa: G001
+
+    def _is_equivalent(self, other: BaseMetadata) -> str:  # pragma: no cover
+        assert isinstance(other, ConfigMetadata)  # noqa: S101
 
         if self.clazz != other.clazz:
             return f"Class not equal. Expected '{self.clazz}', but got '{other.clazz}'"
@@ -78,99 +97,22 @@ class ConfigMetadata:
 
         return ""
 
-    def to_json(self) -> str:
-        """Get a JSON representation of this ``ConfigMetadata``."""
-        raw = self.__dict__.copy()
-        kwargs = dict(
-            versions=raw.pop("versions"),
-            created=raw.pop("created").isoformat(),
-            main=tuple(map(str, raw.pop("main"))),
-            extra_fetchers=[tuple(map(str, t)) for t in raw.pop("extra_fetchers")],
+    @staticmethod
+    def from_toml_paths(
+        path: str,
+        extra_fetchers: List[str],
+        clazz: Type["Translator[Any, Any, Any]"],
+    ) -> "ConfigMetadata":
+        """Convenience function for creating ``ConfigMetadata`` instances."""
+        return ConfigMetadata(
+            main=_create_path_tuple(path),
+            extra_fetchers=tuple(map(_create_path_tuple, extra_fetchers)),
+            clazz=clazz.__module__ + "." + clazz.__qualname__,  # Fully qualified name
         )
-        kwargs["class"] = raw.pop("clazz")
-        assert not raw, f"Not serialized: {raw}."  # noqa:  S101
-        return json.dumps(kwargs, indent=True)
-
-    @classmethod
-    def from_json(cls, s: str) -> "ConfigMetadata":
-        """Create ``ConfigMetadata`` from a JSON string `s`."""
-        raw = json.loads(s)
-
-        def to_path_tuple(args: List[str]) -> Tuple[Path, str]:
-            return Path(args[0]), args[1]
-
-        kwargs = dict(
-            versions=raw.pop("versions"),
-            created=pd.Timestamp.fromisoformat(raw.pop("created")),
-            main=to_path_tuple(raw.pop("main")),
-            extra_fetchers=tuple(map(to_path_tuple, raw.pop("extra_fetchers"))),
-            clazz=raw.pop("class"),
-        )
-        assert not raw, f"Not deserialized: {raw}."  # noqa:  S101
-        return ConfigMetadata(**kwargs)
 
 
-def make_metadata(
-    path: str,
-    extra_fetchers: List[str],
-    clazz: Type["Translator[Any, Any, Any]"],
-) -> ConfigMetadata:
-    """Convenience class for creating ``ConfigMetadata`` instances."""
-    from rics import __version__ as rics
-    from sqlalchemy import __version__ as sqlalchemy
-
-    from id_translation import __version__ as id_translation
-
-    versions = dict(
-        rics=rics,
-        id_translation=id_translation,
-        sqlalchemy=sqlalchemy,
-        pandas=pd.__version__,
-        tomllib=tomllib.__version__ if hasattr(tomllib, "__version__") else None,
-    )
-
-    def create_path_tuple(str_path: str) -> Tuple[Path, str]:
-        p = Path(str_path).expanduser().absolute()
-        with p.open("rb") as f:
-            content = tomllib.load(f)
-        return p, sha256(json.dumps(content).encode()).hexdigest()
-
-    return ConfigMetadata(
-        versions=versions,
-        created=pd.Timestamp.now().round("s"),
-        main=create_path_tuple(path),
-        extra_fetchers=tuple(map(create_path_tuple, extra_fetchers)),
-        clazz=clazz.__module__ + "." + clazz.__qualname__,  # Fully qualified name
-    )
-
-
-def use_cached_translator(
-    metadata_path: Path,
-    wanted_config: ConfigMetadata,
-    max_age: pd.Timedelta,
-) -> bool:
-    """Returns ``True`` if given metadata indicates that the cached ``Translator`` is still viable."""
-
-    def log_reject(reason: str) -> None:
-        LOGGER.info(f"Create new Translator; {reason}. Metadata path='{metadata_path}'.")
-
-    if not metadata_path.exists():
-        log_reject("no cache metadata found")
-        return False
-
-    stored_config = ConfigMetadata.from_json(metadata_path.read_text())
-
-    reason_not_equivalent = wanted_config.is_equivalent(stored_config)
-    if reason_not_equivalent:
-        log_reject(f"cached instance is not equivalent. {reason_not_equivalent}")
-        return False
-
-    expires_at = stored_config.created + max_age
-    offset = abs(pd.Timestamp.now() - expires_at).round("s")
-
-    if expires_at <= stored_config.created:
-        log_reject(f"cache expired at {expires_at} ({offset} ago)")
-        return False
-
-    LOGGER.info(f"Accept cached Translator in '{metadata_path.parent}'. Expires at {expires_at} (in {offset}).")
-    return True
+def _create_path_tuple(str_path: str) -> Tuple[Path, str]:
+    p = Path(str_path).expanduser().absolute()
+    with p.open("rb") as f:
+        content = tomllib.load(f)
+    return p, sha256(json.dumps(content).encode()).hexdigest()

--- a/src/id_translation/_translator.py
+++ b/src/id_translation/_translator.py
@@ -381,6 +381,8 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
                     online=self.online,
                 ),
             )
+        else:
+            pass  # pragma: no cover
 
         return ans
 

--- a/src/id_translation/_translator.py
+++ b/src/id_translation/_translator.py
@@ -16,9 +16,10 @@ from rics.mapping.types import UserOverrideFunction
 from rics.misc import tname
 from rics.performance import format_perf_counter, format_seconds
 
-from . import _config_utils, factory
+from ._config_utils import ConfigMetadata
 from .dio import DataStructureIO, resolve_io
 from .exceptions import ConnectionStatusError, TooManyFailedTranslationsError
+from .factory import TranslatorFactory
 from .fetching import Fetcher
 from .fetching.types import IdsToFetch
 from .offline import Format, TranslationMap
@@ -176,7 +177,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
         # Misc config
         self._allow_name_inheritance = allow_name_inheritance
 
-        self._config_metadata: Optional[_config_utils.ConfigMetadata] = None
+        self._config_metadata: Optional[ConfigMetadata] = None
 
     @classmethod
     def from_config(
@@ -197,14 +198,14 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
         Returns:
             A new ``Translator`` instance with a :attr:`config_metadata` attribute.
         """
-        return factory.TranslatorFactory(
+        return TranslatorFactory(
             path,
             extra_fetchers,
             clazz or cls,  # TODO: Higher-Kinded TypeVars
         ).create()
 
     @property
-    def config_metadata(self) -> _config_utils.ConfigMetadata:
+    def config_metadata(self) -> ConfigMetadata:
         """Return :func:`from_config` initialization metadata."""
         if self._config_metadata is None:
             raise ValueError("Not created using Translator.from_config()")  # pragma: no cover
@@ -581,8 +582,8 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
         * There is no `'metadata'` file, or
         * the original ``Translator`` is too old (see `max_age`), or
         * the current configuration -- as defined by ``(config_path, extra_fetchers, clazz)`` -- has changed in such a
-          way that it is no longer :meth:`equivalent <.ConfigMetadata.is_equivalent>` to the
-          configuration used to create the original ``Translator``.
+          way that it is no longer equivalent configuration used to create the original ``Translator``. For details, see
+          :class:`ConfigMetadata`.
 
         .. warning:: This method is **not** thread safe.
 
@@ -612,12 +613,12 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
 
         extra_fetcher_paths: List[str] = list(map(str, extra_fetchers))
 
-        metadata = _config_utils.make_metadata(
+        metadata = ConfigMetadata.from_toml_paths(
             str(path),
             extra_fetcher_paths,
-            clazz=factory.TranslatorFactory.resolve_class(clazz),
+            clazz=TranslatorFactory.resolve_class(clazz),
         )
-        if _config_utils.use_cached_translator(metadata_path, metadata, pd.Timedelta(max_age)):
+        if metadata.use_cached(metadata_path, pd.Timedelta(max_age).to_pytimedelta()):
             return cls.restore(cache_path)
         else:
             ans: Translator[NameType, SourceType, IdType] = cls.from_config(path, extra_fetcher_paths, clazz)

--- a/src/id_translation/factory.py
+++ b/src/id_translation/factory.py
@@ -12,7 +12,8 @@ from rics._internal_support.types import PathLikeType
 from rics.collections import dicts
 from rics.mapping import HeuristicScore as _HeuristicScore, Mapper as _Mapper
 
-from . import _config_utils, exceptions, fetching
+from . import exceptions, fetching
+from ._config_utils import ConfigMetadata as _ConfigMetadata
 from .types import IdType, NameType, SourceType
 
 if TYPE_CHECKING:
@@ -157,7 +158,7 @@ class TranslatorFactory(_Generic[NameType, SourceType, IdType]):
             **translator_config,
         )
 
-        ans._config_metadata = _config_utils.make_metadata(
+        ans._config_metadata = _ConfigMetadata.from_toml_paths(
             self.file,
             self.extra_fetchers,
             self.clazz,

--- a/src/id_translation/fetching/__init__.py
+++ b/src/id_translation/fetching/__init__.py
@@ -16,6 +16,7 @@ Base fetchers:
       `placeholder mapping <../documentation/translation-primer.html#placeholder-mapping>`__.
 """
 from ._abstract_fetcher import AbstractFetcher
+from ._cache import CacheAccess, CacheMetadata
 from ._fetcher import Fetcher
 from ._memory_fetcher import MemoryFetcher
 from ._multi_fetcher import MultiFetcher
@@ -25,6 +26,8 @@ from ._sql_fetcher import SqlFetcher
 __all__ = [
     "Fetcher",
     "AbstractFetcher",
+    "CacheAccess",
+    "CacheMetadata",
     "MemoryFetcher",
     "MultiFetcher",
     "PandasFetcher",

--- a/src/id_translation/fetching/_abstract_fetcher.py
+++ b/src/id_translation/fetching/_abstract_fetcher.py
@@ -155,7 +155,7 @@ class AbstractFetcher(Fetcher[SourceType, IdType]):
 
     @property
     def online(self) -> bool:
-        return True  # pragma: no cover
+        return False  # pragma: no cover
 
     def assert_online(self) -> None:
         """Raise an error if offline.

--- a/src/id_translation/fetching/_cache.py
+++ b/src/id_translation/fetching/_cache.py
@@ -1,0 +1,191 @@
+import logging
+import pickle  # noqa: 403
+from dataclasses import dataclass
+from datetime import timedelta
+from pathlib import Path
+from typing import Any, Dict, Generic, List, Optional, Union
+
+import pandas as pd
+
+from id_translation._base_metadata import BaseMetadata
+from id_translation.types import HasSources, IdType, SourceType
+
+from ..offline.types import PlaceholderTranslations, SourcePlaceholderTranslations
+
+BASE_LOGGER = logging.getLogger(__package__).getChild("CacheMetadata")
+
+
+@dataclass(eq=False)
+class CacheMetadata(BaseMetadata, Generic[SourceType, IdType], HasSources[SourceType]):
+    """Metadata pertaining to fetcher caching logic.
+
+    Args:
+        cache_keys: Hierarchical identifiers for the cache. The first key is used to determine storage location, while
+            the rest are used to detect configuration changes (which invalidate the cache). A typical key would be
+            ``[config-file-name, config-file-sha]``.
+        placeholders: A Source-to-placeholder dict.
+        **kwargs: Forwarded to base classes.
+    """
+
+    def __init__(
+        self,
+        cache_keys: List[str],
+        placeholders: Dict[SourceType, List[str]],
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        if not cache_keys:  # pragma: no cover
+            raise ValueError("Must specify at least one cache key.")
+        self._cache_keys = cache_keys
+        self._placeholders = placeholders
+
+    @property
+    def cache_keys(self) -> List[str]:
+        """Yields hierarchical cache keys for this metadata."""
+        return self._cache_keys.copy()
+
+    @property
+    def placeholders(self) -> Dict[SourceType, List[str]]:
+        return self._placeholders
+
+    def _is_equivalent(self, other: "BaseMetadata") -> str:
+        assert isinstance(other, CacheMetadata)  # noqa: S101
+
+        if self._cache_keys != other._cache_keys:
+            return f"Expected cache_keys={self._cache_keys} (requested) but got {other._cache_keys}"
+
+        if list(self.placeholders) != list(other.placeholders):
+            return f"Expected sources={list(self.placeholders)} (requested) but got {list(other.placeholders)}"
+
+        for source, expected in self.placeholders.items():
+            if sorted(expected) != sorted(other.placeholders[source]):
+                return f"For {source=}, expected placeholders={expected} but got {other.placeholders[source]}"
+
+        return ""
+
+    @property
+    def _logger(self) -> logging.Logger:
+        return BASE_LOGGER.getChild(self.cache_keys[0])
+
+    def _log_reject(self, msg: str) -> None:
+        self._logger.debug(msg.format(slug="Fetch new translations"))  # noqa: G001
+
+    def _log_accept(self, msg: str) -> None:
+        self._logger.debug(msg.format(kind="translations"))  # noqa: G001
+
+    def _serialize(self, to_json: Dict[str, Any]) -> Dict[str, Any]:
+        ans = to_json.copy()
+        to_json.clear()
+        return ans
+
+    @classmethod
+    def _deserialize(cls, from_json: Dict[str, Any]) -> Dict[str, Any]:
+        return dict(cache_keys=from_json.pop("_cache_keys"), placeholders=from_json.pop("_placeholders"))
+
+
+class CacheAccess(Generic[SourceType, IdType]):
+    """Utility class for managing the FETCH_ALL-cache.
+
+    Args:
+        max_age: Cache timeout.
+        metadata: Metadata object used to determine cache validity.
+    """
+
+    @classmethod
+    def base_cache_dir(cls) -> Path:
+        """Top-level cache dir for all fetchers managed by any ``CacheAccess``-instance."""
+        return Path.home().absolute().joinpath(".cache/id-translation/cached-fetcher-data/")
+
+    @classmethod
+    def clear_all_cache_data(cls) -> None:
+        """Remove the entire cache directory tree for ALL instances."""
+        import shutil
+
+        cache_dir = cls.base_cache_dir()
+        print(f"Deleting the common cache directory tree at:\n    '{cache_dir}'")
+        shutil.rmtree(cache_dir)
+
+    def __init__(
+        self,
+        max_age: Union[str, pd.Timedelta, timedelta],
+        metadata: CacheMetadata[SourceType, IdType],
+    ) -> None:
+        pd_timedelta = pd.Timedelta(max_age)
+        if pd_timedelta <= pd.Timedelta(0):
+            raise ValueError("fetch_all_cache_max_age must be non-negative")  # pragma: no cover
+        self._max_age = pd_timedelta.to_pytimedelta()
+        self._metadata: CacheMetadata[SourceType, IdType] = metadata
+        top_level_key = next(iter(self._metadata.cache_keys))
+        self._base_dir = self.base_cache_dir().joinpath(top_level_key)
+        self._logger = logging.getLogger(__package__).getChild("CacheAccess").getChild(top_level_key)
+
+    @property
+    def cache_dir(self) -> Path:
+        """The cache directory for a fetcher, created from :meth:`base_cache_dir` and the first value of :attr:`CacheMetadata.cache_keys`."""
+        return self._base_dir
+
+    @property
+    def metadata_path(self) -> Path:
+        return self._base_dir.joinpath("metadata.json")
+
+    @property
+    def data_path(self) -> Path:
+        return self._base_dir.joinpath("data.pkl")
+
+    def read_cache(self, source: SourceType) -> Optional[PlaceholderTranslations[SourceType]]:
+        """Read cached translation data for `source`."""
+        if not self._metadata.use_cached(self.metadata_path, self._max_age):
+            return None
+
+        with self.data_path.open("rb") as f:
+            try:
+                spt = pickle.load(f)  # noqa: S301
+                ans = spt[source]
+                if not isinstance(ans, PlaceholderTranslations):  # pragma: no cover
+                    reason = f"Got {type(ans).__name__} but expected {PlaceholderTranslations.__name__}."
+                    self.clear(reason)
+                    raise TypeError(reason)
+
+                self._logger.debug(f"Returning cached data for {source=}", extra=dict(source=source))
+                return ans
+            except IOError:
+                self._logger.warning("Could not read cached data from:\n    path='%s'", self.data_path, exc_info=True)
+            except (TypeError, KeyError, pickle.UnpicklingError) as e:
+                self.clear(f"Got error {e} while deserializing")
+                self._logger.exception(
+                    f"Failed to read cache for {source=}. Corrupted files have been removed.", extra=dict(source=source)
+                )
+        return None
+
+    def write_cache(self, data: SourcePlaceholderTranslations[SourceType]) -> None:
+        """Overwrite the current cache (if it exists) with new and update metadata."""
+        if self.metadata_path.exists():
+            self._logger.debug(f"Overwriting existing cache data in '{self.cache_dir}'.")
+
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+        self.metadata_path.write_text(self._metadata.to_json())
+        with self.data_path.open("wb") as f:
+            pickle.dump(data, f)
+
+    def clear(self, reason: str) -> None:
+        """Remove cached data for the current instance."""
+        reason = ": " + reason
+
+        deleted = []
+
+        if self.data_path.exists():
+            self.data_path.unlink(missing_ok=True)
+            deleted.append(self.data_path)
+
+        if self.metadata_path.exists():
+            self.metadata_path.unlink(missing_ok=True)
+            deleted.append(self.metadata_path)
+
+        if self._logger.isEnabledFor(logging.DEBUG):
+            if not deleted:
+                delete_info = "    There is nothing to delete."
+            else:
+                delete_info = "\n".join(map("    - {}".format, deleted))
+
+            self._logger.debug(f"Clear cache: {reason}. The follow files have been deleted:\n{delete_info}")

--- a/src/id_translation/fetching/_pandas_fetcher.py
+++ b/src/id_translation/fetching/_pandas_fetcher.py
@@ -31,6 +31,8 @@ class PandasFetcher(AbstractFetcher[str, IdType]):
             Must contain a `source` as its only placeholder. Example: ``data/{source}.pkl``. Leave as-is if ``None``.
             Valid URL schemes include http, ftp, s3, gs, and file.
         read_function_kwargs: Additional keyword arguments for `read_function`.
+        online: Setting ``online=False`` typically indicates that files are hosted at a location where there are access
+            limitations, e.g. through data transfer fees.
 
     See Also:
         The official `Pandas IO documentation <https://pandas.pydata.org/pandas-docs/stable/user_guide/io.html>`_
@@ -41,6 +43,7 @@ class PandasFetcher(AbstractFetcher[str, IdType]):
         read_function: Union[PandasReadFunction, str] = "read_pickle",
         read_path_format: Union[str, FormatFn] = "data/{}.pkl",
         read_function_kwargs: Mapping[str, Any] = None,
+        online: bool = False,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -50,6 +53,7 @@ class PandasFetcher(AbstractFetcher[str, IdType]):
             self._format_source = read_path_format  # pragma: no cover
         else:
             self._format_source = read_path_format.format
+        self._online = online
         self._kwargs = read_function_kwargs or {}
 
         self._source_paths: Dict[str, Path] = {}
@@ -120,6 +124,10 @@ class PandasFetcher(AbstractFetcher[str, IdType]):
             instr.source,
             self.read(self._source_paths[instr.source]),
         )
+
+    @property
+    def online(self) -> bool:
+        return self._online
 
     def __repr__(self) -> str:
         read_path_format = self._format_source("{source}")

--- a/src/id_translation/testing.py
+++ b/src/id_translation/testing.py
@@ -56,7 +56,7 @@ class TestFetcher(_Fetcher[SourceType, IdType]):
 
     @property
     def online(self) -> bool:
-        return True  # pragma: no cover
+        return False  # pragma: no cover
 
     @property
     def placeholders(self) -> Dict[SourceType, List[str]]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import json
+import logging
 from functools import partialmethod
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
@@ -15,6 +17,14 @@ from id_translation.offline.types import PlaceholderTranslations
 ROOT: Path = Path(__file__).parent
 
 Mapper.__init__ = partialmethod(Mapper.__init__, verbose_logging=True)  # type: ignore[assignment]
+
+
+class CheckSerializeToJson(logging.Handler):
+    def emit(self, record: logging.LogRecord) -> None:
+        json.dumps(record.__dict__)
+
+
+logging.root.addHandler(CheckSerializeToJson())
 
 
 class HexFetcher(AbstractFetcher[str, int]):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,9 @@ Mapper.__init__ = partialmethod(Mapper.__init__, verbose_logging=True)  # type: 
 
 class CheckSerializeToJson(logging.Handler):
     def emit(self, record: logging.LogRecord) -> None:
-        json.dumps(record.__dict__)
+        d = record.__dict__.copy()
+        d.pop("exc_info", None)
+        json.dumps(d)
 
 
 logging.root.addHandler(CheckSerializeToJson())

--- a/tests/fetching/conftest.py
+++ b/tests/fetching/conftest.py
@@ -1,3 +1,7 @@
+import os
+import time
+from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Dict
 
 import pandas as pd
@@ -14,3 +18,12 @@ def data() -> Dict[str, pd.DataFrame]:
         "big_table": pd.DataFrame({"id": range(100)}),
         "huge_table": pd.DataFrame({"id": range(1000)}),
     }
+
+
+@pytest.fixture(scope="module")
+def windows_hack_temp_dir():
+    with TemporaryDirectory() as tmpdir:
+        yield Path(tmpdir)
+        if os.name == "nt":
+            # Windows seems more sensitive to this. Sleep a while to make sure things can let go of connections.
+            time.sleep(5)

--- a/tests/fetching/test_abstract_fetcher.py
+++ b/tests/fetching/test_abstract_fetcher.py
@@ -1,7 +1,11 @@
+from typing import Dict
+
+import pandas as pd
 import pytest
+from rics.collections.misc import as_list
 from rics.mapping import Mapper
 
-from id_translation.fetching import AbstractFetcher, MemoryFetcher, exceptions
+from id_translation.fetching import AbstractFetcher, CacheAccess, MemoryFetcher, exceptions
 from id_translation.fetching.types import IdsToFetch
 
 
@@ -52,3 +56,132 @@ def test_selective_fetch_all(data, selective_fetch_all, required, expected):
 def test_test_crashes_with_selective_fetch_all_disabled(data):
     with pytest.raises(exceptions.UnknownPlaceholderError):
         MemoryFetcher(data, selective_fetch_all=False).fetch_all(required=("id", "name"))
+
+
+@pytest.fixture(scope="module")
+def fetch_all_cache_dir(windows_hack_temp_dir):
+    yield windows_hack_temp_dir.joinpath("abstract-fetcher-cache")
+
+
+@pytest.mark.parametrize(
+    "operations, expected_call_counts, clear",
+    [
+        # Order matters!
+        (["all", "one", "all"], [4, 4, 4], False),
+        (["one", "all", "all"], [0, 0, 0], False),
+        (["one", "all", "all"], [1, 5, 5], True),
+        (["one", "one", "one", "one", "all", "one"], [1, 2, 3, 4, 8, 8], True),
+        (["one", "one", "one", "one", "all", "one"], [0, 0, 0, 0, 0, 0], False),
+    ],
+    ids=lambda v: "_".join(map(str, as_list(v))),
+)
+def test_cache_with_call_count(
+    fetch_all_cache_dir,
+    fetcher,
+    operations,
+    expected_call_counts,
+    clear,
+):
+    CacheAccess.base_cache_dir = lambda _: fetch_all_cache_dir.joinpath("test_cache_with_call_count")  # type: ignore
+
+    assert len(operations) == len(expected_call_counts)
+    expected_data = fetcher.fetch_all()
+
+    test_fetcher = CacheTestFetcher(fetcher._data, key="test_cache_with_call_count")
+    if clear:
+        test_fetcher.clear_cache("test case")
+
+    for i, (op, expected_count) in enumerate(zip(operations, expected_call_counts)):
+        msg = f"Step {i}: {op}({expected_count})"
+
+        if op == "all":
+            fetch_all_actual = test_fetcher.fetch_all()
+            assert fetch_all_actual == expected_data, msg
+        else:
+            fetch_actual = test_fetcher.fetch([IdsToFetch("humans", [1, 2])])["humans"]
+            expected = expected_data["humans"]
+            assert fetch_actual == expected, msg
+
+        assert test_fetcher.fetch_translations_call_count == expected_count, msg
+
+
+def test_cache_doesnt_refresh_itself(data, fetch_all_cache_dir):
+    CacheAccess.base_cache_dir = lambda _: fetch_all_cache_dir.joinpath("doesnt_refresh_itself")  # type: ignore
+    test_fetcher = CacheTestFetcher(data, key="doesnt_refresh_itself")
+    test_fetcher.fetch_all()
+    metadata_path = test_fetcher._create_cache_access().metadata_path
+    expected_metadata = metadata_path.read_text()
+
+    for _ in range(4):
+        test_fetcher.fetch_all()
+
+    actual_metadata = metadata_path.read_text()
+    assert actual_metadata == expected_metadata
+
+
+def test_corrupted_cache(caplog, fetcher, fetch_all_cache_dir):
+    test_root = fetch_all_cache_dir.joinpath("test_corrupted_cache")
+    CacheAccess.base_cache_dir = lambda *_: test_root  # type: ignore
+    test_fetcher = CacheTestFetcher(fetcher._data, key="test_corrupted_cache")
+    test_fetcher.fetch_all()
+    caplog.clear()
+
+    access = test_fetcher._create_cache_access()
+    access.data_path.write_text("Corrupted data!")
+    with caplog.at_level("DEBUG"):
+        assert test_fetcher._get_cached_translations("humans") is None
+
+    assert not access.data_path.exists()
+    assert not access.metadata_path.exists()
+
+    wanted_substrings = [access.data_path, access.metadata_path]
+    expected = list(map(str, wanted_substrings))
+    actual = []
+    for message in caplog.messages:
+        for w in expected:
+            if w in message:
+                actual.append(w)
+
+    assert actual == expected, "Some wanted log messages weren't found."
+    assert test_root.exists()
+    CacheAccess.clear_all_cache_data()
+    assert not test_root.exists()
+
+
+def test_placeholders_invalidate_cache(data, fetch_all_cache_dir):
+    CacheAccess.base_cache_dir = lambda _: fetch_all_cache_dir.joinpath("placeholders")  # type: ignore
+    data = data.copy()
+
+    original_metadata = CacheTestFetcher(data, key="new_placeholders")._create_cache_access()._metadata
+
+    del data["animals"]
+    no_animals_metadata = CacheTestFetcher(data, key="new_placeholders")._create_cache_access()._metadata
+    assert "Expected sources=['" in no_animals_metadata.is_equivalent(original_metadata)
+
+    del data["humans"]["name"]
+    no_name_humans = CacheTestFetcher(data, key="new_placeholders")._create_cache_access()._metadata
+    assert "For source='humans', expected placeholders" in no_animals_metadata.is_equivalent(no_name_humans)
+
+
+def test_new_cache_key_invalidates_cache():
+    first_metadata = CacheTestFetcher({}, key="first")._create_cache_access()._metadata
+    second_metadata = CacheTestFetcher({}, key="second")._create_cache_access()._metadata
+    assert str(second_metadata.cache_keys) in second_metadata.is_equivalent(first_metadata)
+
+
+class CacheTestFetcher(MemoryFetcher[str, int]):
+    def __init__(self, data: Dict[str, pd.DataFrame], key: str) -> None:
+        super().__init__(data, fetch_all_cache_max_age="100d", cache_keys=[CacheTestFetcher.__name__] + [key])
+        self.fetch_translations_call_count = 0
+        self._online = True
+
+    def set_online(self, online: bool) -> None:
+        self._online = online
+
+    @property
+    def online(self) -> bool:
+        return self._online
+
+    def fetch_translations(self, instr):
+        self.fetch_translations_call_count += 1
+        return super().fetch_translations(instr)

--- a/tests/fetching/test_sql_fetcher.py
+++ b/tests/fetching/test_sql_fetcher.py
@@ -1,8 +1,3 @@
-import os
-import time
-from os.path import join
-from tempfile import TemporaryDirectory
-
 import pytest as pytest
 import sqlalchemy
 from rics.collections.dicts import InheritedKeysDict
@@ -75,15 +70,12 @@ def sql_fetcher(connection_string):
 
 
 @pytest.fixture(scope="module")
-def connection_string(data):
-    with TemporaryDirectory() as tmpdir:
-        db_file = join(tmpdir, "sqlfetcher-test-database.sqlite")
-        connection_string = f"sqlite:///{db_file}"
-        insert_data(connection_string, data)
-        yield connection_string
-        if os.name == "nt":
-            # Windows seems more sensitive to this. Sleep a while to make sure all engines close their connections.
-            time.sleep(5)
+def connection_string(data, windows_hack_temp_dir):
+    db_file = windows_hack_temp_dir.joinpath(windows_hack_temp_dir, "sql-fetcher-data")
+    db_file.mkdir(parents=True, exist_ok=True)
+    connection_string = f"sqlite:///{db_file.joinpath('db.sqlite')}"
+    insert_data(connection_string, data)
+    yield connection_string
 
 
 def insert_data(connection_string, data):

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -4,5 +4,5 @@ import pytest
 
 
 def test_not_serializable_fails():
-    with pytest.raises(AssertionError, match="This should fail!"):
+    with pytest.raises(TypeError):
         logging.root.info("This should fail!", extra=dict(bad_key={"sets aren't serializable"}))

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -46,8 +46,11 @@ class Translator(RealTranslator[str, str, IdType]):
         return super()._map_inner(translatable, names, ignore_names, override_function, parent)
 
 
-@dataclass(frozen=True)
+@dataclass
 class ConfigMetadataForTest(_config_utils.ConfigMetadata):
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+
     def __post_init__(self) -> None:
         assert self.clazz in ("id_translation._translator.Translator", "tests.test_translator.Translator")
 


### PR DESCRIPTION
Only active for `online`-fetchers. The default value for `AbstractFetcher.online` has changed from `True` to `False`. The `PandasFetcher` can now set choose value explicitly at creation.

Closes #46 