### PR TITLE
Generalize filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Clean up and rename a large number of heuristic and filter functions.
 - Changed the default score function of the `Mapper` from `equality` to `disabled`.
+- The `TranslatorFactory` now makes an effort to include the source file of config issues.
 
 ### Fixed
 - Duplicate explicit names are now supported for most types (closes #4).

--- a/docs/documentation/translator-config.rst
+++ b/docs/documentation/translator-config.rst
@@ -228,14 +228,14 @@ matches, for example SQL tables which should not be used or a ``DataFrame`` colu
    Additional keys depend on the chosen function implementation.
 
 As an example, the next snippet ensures that only names ending with an ``'_id'``-suffix will be translated by using a
-:func:`~id_translation.mapping.filter_functions.keep_names`-filter.
+:func:`~id_translation.mapping.filter_functions.filter_names`-filter.
 
 .. code-block:: toml
 
     [[translator.mapping.filter_functions]]
-    function = "keep_names"
+    function = "filter_names"
     regex = ".*_id$"
-
+    remove = false  # This is the default (like the built-in filter).
 
 Score function
 ~~~~~~~~~~~~~~

--- a/tests/dvdrental/sql-fetcher.toml
+++ b/tests/dvdrental/sql-fetcher.toml
@@ -13,8 +13,9 @@ blacklist_tables = [
 unmapped_values_action = "ignore"
 
 [[fetching.mapping.filter_functions]]
-function = "remove_sources"
+function = "filter_sources"
 regex = ".*p2007.*"
+remove = true
 
 [[fetching.mapping.score_function_heuristics]]
 function = "value_fstring_alias"

--- a/tests/dvdrental/translation.toml
+++ b/tests/dvdrental/translation.toml
@@ -15,8 +15,9 @@ score_function = "modified_hamming"
 function = "like_database_table"
 
 [[translator.mapping.filter_functions]]
-function = "keep_names"
+function = "filter_names"
 regex = ".*_id$"
+remove = false  # This is the default (like the built-in filter).
 
 ################################################################################
 # Parallel fetching configuration.

--- a/tests/fetching/test_sql_fetcher.py
+++ b/tests/fetching/test_sql_fetcher.py
@@ -114,7 +114,7 @@ def test_unmappable_whitelist_table(use_override, connection_string):
     mapper = Mapper(
         score_fn,
         overrides={"id": "bad-column"} if use_override else None,
-        filter_functions=[("remove_placeholders", dict(regex=""))],
+        filter_functions=[("filter_placeholders", dict(regex="", remove=True))],
     )
 
     fetcher = SqlFetcher(connection_string, mapper=mapper, whitelist_tables=["animals", "big_table", "huge_table"])

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,11 +1,13 @@
-from typing import Any, Optional, Type
+from typing import Any, Type
 
 import pytest
 
 from id_translation import Translator
-from id_translation.factory import TranslatorFactory, default_fetcher_factory
+from id_translation.factory import TranslatorFactory, _ConfigurationErrorWithFile, default_fetcher_factory
 from id_translation.fetching import AbstractFetcher, MemoryFetcher
 from id_translation.types import IdType, SourceType
+
+from .conftest import ROOT
 
 
 class AnotherFetcherType(MemoryFetcher[SourceType, IdType]):
@@ -28,6 +30,20 @@ def test_default_fetcher_factory(
     assert isinstance(fetcher, expected_type)
 
 
-@pytest.mark.parametrize("arg", [None, "id_translation.Translator", "id_translation._translator.Translator"])
-def test_resolve_class(arg: Optional[Type[Translator[Any, Any, Any]]]) -> None:
-    assert TranslatorFactory.resolve_class(arg) == Translator
+@pytest.mark.parametrize(
+    "clazz",
+    [
+        None,
+        "id_translation.Translator",
+        "id_translation._translator.Translator",
+        Translator,
+    ],
+)
+def test_resolve_class(clazz):
+    assert TranslatorFactory.resolve_class(clazz) == Translator
+
+
+def test_missing_config():
+    with pytest.raises(_ConfigurationErrorWithFile) as e:
+        Translator.from_config(ROOT.joinpath("bad-config.toml"))
+    assert "bad-config.toml" in str(e.value)

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -10,7 +10,7 @@ import pytest
 
 from id_translation import Translator as RealTranslator, _config_utils
 from id_translation.dio.exceptions import NotInplaceTranslatableError, UntranslatableTypeError
-from id_translation.exceptions import ConfigurationError, TooManyFailedTranslationsError
+from id_translation.exceptions import TooManyFailedTranslationsError
 from id_translation.mapping import Mapper
 from id_translation.mapping.exceptions import MappingError, MappingWarning, UserMappingError
 from id_translation.types import IdType
@@ -148,11 +148,6 @@ def test_bad_translatable(translator, data, clazz, kwargs):
 
 def test_from_config():
     Translator.from_config(ROOT.joinpath("config.toml"))
-
-
-def test_missing_config():
-    with pytest.raises(ConfigurationError):
-        Translator.from_config(ROOT.joinpath("bad-config.toml"))
 
 
 def test_store_and_restore(hex_fetcher, tmp_path):


### PR DESCRIPTION
- Rename filter functions to `filter_<field>`.
- Add remove-flag (`False` by default, to match the built-in filter).

Also:
- Include source file in some messages thrown for bad configs.
