### PR TITLE
Features ahoy!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- A name-to-source dict may now be passed in place of the names `'names'`-argument.
 - Add environment variable `ID_TRANSLATION_DISABLED` to globally disable translation. Emits `TranslationDisabledWarning`
   once.
 - New exception type `MissingNamesError`. Raised when names cannot be derived (and not explicitly given) based on the
@@ -17,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add handling of attributes of retrieved translation elements (e.g. `UUID.int`).
 - The `AbstractFetcher.selective_fetch_all`-flag now restricts the columns retrieved by `SqlFetcher`.
 - Extend `heuristic_functions.like_database_table` to handle more pluralization types.
+- Explicit `names` may no longer combined with `ignored_names`.
 
 ### Fixed
 - Translation of `pandas.MultiIndex` is now properly supported (as indicated by not throwing `UntranslatableTypeError`).
@@ -24,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `'{uuid!s:.8}:{name!r}'` will now work as expected.
 - Ensure deterministic match selection when scores are equal due to overrides.
 - Ensure placeholders aren't fetched twice in the same query.
+- Prevent crashing when using a non-translatable parent type with the `'attribute'`-argument.
 
 ### Removed
 - The now unused module `fetching.support`, and the function `SqlFetcher.TableSummary.select_columns()`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - A name-to-source dict may now be passed in place of the names `'names'`-argument.
+- Translation of `set`-type data is now supported.
 - Add environment variable `ID_TRANSLATION_DISABLED` to globally disable translation. Emits `TranslationDisabledWarning`
   once.
 - New exception type `MissingNamesError`. Raised when names cannot be derived (and not explicitly given) based on the
@@ -19,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `AbstractFetcher.selective_fetch_all`-flag now restricts the columns retrieved by `SqlFetcher`.
 - Extend `heuristic_functions.like_database_table` to handle more pluralization types.
 - Explicit `names` may no longer combined with `ignored_names`.
+- Improve support for translation of heterogeneous `dict` value types.
 
 ### Fixed
 - Translation of `pandas.MultiIndex` is now properly supported (as indicated by not throwing `UntranslatableTypeError`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Ability to mark a fetcher as _optional_. In multi-fetcher mode, optional fetchers are discarded if they raise an error
+  the first time a source/placeholder enumeration is requested.
 - A name-to-source dict may now be passed in place of the names `'names'`-argument.
 - Translation of `set`-type data is now supported.
 - Add environment variable `ID_TRANSLATION_DISABLED` to globally disable translation. Emits `TranslationDisabledWarning`

--- a/docs/documentation/translator-config.rst
+++ b/docs/documentation/translator-config.rst
@@ -98,8 +98,6 @@ a :class:`~id_translation.fetching.MemoryFetcher` would be created by adding a `
      - :py:class:`bool`
      - Control access to :func:`~id_translation.fetching.Fetcher.fetch_all`.
      - Some fetchers types redefine or ignore this key.
-
-
    * - | fetch_all_unmapped
        | _values_action
      - `raise | warn | ignore`
@@ -116,9 +114,13 @@ a :class:`~id_translation.fetching.MemoryFetcher` would be created by adding a `
      - Specified as a string, eg `'12h'` or `'30d'`.
      - Set to non-zero value to enable.
    * - cache_keys
-     - :py:class:`Sequence[str] <typing.Sequence>`.
+     - :py:class:`Sequence[str] <typing.Sequence>`
      - Hierarchical identifier for the cache.
      - Provided automatically if not given.
+   * - optional
+     - :py:class:`bool`
+     - If ``True``, discard on :attr:`~id_translation.fetching.Fetcher.sources`-resolution crash.
+     - Multi-fetcher mode only.
 
 The keys listed above are for the :class:`~id_translation.fetching.AbstractFetcher` class, which all fetchers created by
 TOML configuration must inherit. Additional parameters vary based on the chosen implementation. See the

--- a/src/id_translation/dio/_data_structure_io.py
+++ b/src/id_translation/dio/_data_structure_io.py
@@ -24,7 +24,7 @@ class DataStructureIO:
         Returns:
             A list of names to translate. Returns ``None`` if names cannot be extracted.
         """
-        return None
+        return translatable.name if hasattr(translatable, "name") else None
 
     @staticmethod
     @abstractmethod

--- a/src/id_translation/dio/_resolve.py
+++ b/src/id_translation/dio/_resolve.py
@@ -5,6 +5,7 @@ from . import DataStructureIO
 from ._dict import DictIO
 from ._pandas import PandasIO
 from ._sequence import SequenceIO
+from ._set import SetIO
 from ._single_value import SingleValueIO
 from .exceptions import UntranslatableTypeError
 
@@ -21,7 +22,7 @@ def resolve_io(arg: Translatable) -> Type[DataStructureIO]:
     Raises:
         UntranslatableTypeError: If not IO could be found.
     """
-    for tio_class in DictIO, PandasIO, SequenceIO, SingleValueIO:
+    for tio_class in DictIO, SetIO, PandasIO, SequenceIO, SingleValueIO:
         if tio_class.handles_type(arg):
             return tio_class
 

--- a/src/id_translation/dio/_set.py
+++ b/src/id_translation/dio/_set.py
@@ -1,0 +1,34 @@
+from typing import Any, Dict, List, Optional, Sequence, Set
+
+from ..offline import TranslationMap
+from ..types import IdType, NameType, SourceType
+from ._data_structure_io import DataStructureIO
+
+
+class SetIO(DataStructureIO):
+    """Implementation for dicts."""
+
+    @staticmethod
+    def handles_type(arg: Any) -> bool:
+        return isinstance(arg, set)
+
+    @staticmethod
+    def extract(translatable: Set[IdType], names: List[NameType]) -> Dict[NameType, Sequence[IdType]]:
+        if len(names) != 1:  # pragma: no cover
+            raise ValueError("Length of names must be one.")
+
+        return {names[0]: list(translatable)}
+
+    @staticmethod
+    def insert(
+        translatable: Set[IdType], names: List[NameType], tmap: TranslationMap[NameType, SourceType, IdType], copy: bool
+    ) -> Optional[Set[Optional[str]]]:
+        magic_dict = tmap[names[0]]
+        translated = {magic_dict.get(e) for e in translatable}
+
+        if copy:
+            return translated
+
+        translatable.clear()
+        translatable.update(translated)  # type: ignore[arg-type]
+        return None

--- a/src/id_translation/fetching/_fetcher.py
+++ b/src/id_translation/fetching/_fetcher.py
@@ -22,6 +22,18 @@ class Fetcher(Generic[SourceType, IdType], HasSources[SourceType]):
     def online(self) -> bool:
         """Return connectivity status. If ``False``, no new translations may be fetched."""
 
+    @property
+    def optional(self) -> bool:
+        """Return ``True`` if this fetcher has been marked as `optional`.
+
+        In multi-fetcher mode, optional fetchers may be discarded if :attr:`~.HasSources.sources` cannot be resolved
+        (raises an exception). Default value is ``False``.
+
+        Returns:
+            Optionality status.
+        """
+        return False
+
     @abstractmethod
     def fetch(
         self,

--- a/src/id_translation/mapping/_mapper.py
+++ b/src/id_translation/mapping/_mapper.py
@@ -323,7 +323,7 @@ class Mapper(Generic[ValueType, CandidateType, ContextType]):
             ):
                 if self.logger.isEnabledFor(logging.DEBUG):
                     self.logger.debug(
-                        f"Using override {repr(value)} -> {repr(override_candidate)} returned by {override_function}."
+                        f"Using override {repr(value)} -> {repr(override_candidate)} returned by {override_function=}."
                     )
                 apply(value, override_candidate)
 
@@ -374,7 +374,8 @@ class Mapper(Generic[ValueType, CandidateType, ContextType]):
             if self.unknown_user_override_action is not ActionLevel.IGNORE and user_override not in candidates:
                 msg = (
                     f"The user-defined override function {func} returned an unknown candidate={repr(user_override)} for"
-                    f" {value=}. If this is intended behaviour, set unknown_user_override_action='ignore' to allow."
+                    f" {value=}."
+                    "\nHint: If this is intended behaviour, set unknown_user_override_action='ignore' to allow."
                 )
                 if self.unknown_user_override_action is ActionLevel.RAISE:
                     self.logger.error(msg)

--- a/src/id_translation/offline/_translation_map.py
+++ b/src/id_translation/offline/_translation_map.py
@@ -4,13 +4,11 @@ from typing import Any, Dict, Generic, Iterator, List, Mapping, Optional, Set, U
 from rics.collections.dicts import InheritedKeysDict, reverse_dict
 from rics.misc import tname
 
-from ..types import HasSources, IdType, NameType, SourceType
+from ..types import HasSources, IdType, NameToSource, NameType, SourceType
 from ._format import Format
 from ._format_applier import FormatApplier
 from ._magic_dict import MagicDict
 from .types import FormatType, SourcePlaceholderTranslations
-
-NameToSource = Dict[NameType, SourceType]
 
 
 class TranslationMap(

--- a/src/id_translation/types.py
+++ b/src/id_translation/types.py
@@ -17,6 +17,7 @@ Translatable = _type.TypeVar(
     str,
     int,
     _type.Dict,  # type: ignore[type-arg]  # TODO: Need Higher-Kinded TypeVars
+    _type.Set,  # type: ignore[type-arg]  # TODO: Need Higher-Kinded TypeVars
     _type.Sequence,  # type: ignore[type-arg]  # TODO: Need Higher-Kinded TypeVars
     "NDArray",  # type: ignore[type-arg]  # TODO: Need Higher-Kinded TypeVars
     "pandas.DataFrame",

--- a/src/id_translation/types.py
+++ b/src/id_translation/types.py
@@ -43,6 +43,9 @@ IdType = _type.TypeVar("IdType", int, str, _UUID)
 SourceType = _type.TypeVar("SourceType", bound=_type.Hashable)
 """Type used to describe sources. Typically a string for things like files and database tables."""
 
+NameToSource = _type.Dict[NameType, SourceType]
+"""A mapping from name to source."""
+
 NamesPredicate = _type.Callable[[NameType], bool]
 """A predicate type on names."""
 NameTypes = _type.Union[NameType, _type.Iterable[NameType]]

--- a/tests/dio/test_extract.py
+++ b/tests/dio/test_extract.py
@@ -8,8 +8,20 @@ NAMES = list("abcd")
 VALUES = [3, 1, 5, 6]
 
 
+@pytest.mark.parametrize("ttype", [set, list, tuple, pd.Index, pd.Series, np.array])
+def test_extract_single_explicit_name(ttype):
+    try:
+        data = ttype(VALUES, name="not-a")
+    except TypeError:
+        data = ttype(VALUES)
+
+    actual = resolve_io(data).extract(data, names=["a"])
+    assert len(actual) == 1
+    assert sorted(actual["a"]) == sorted(VALUES)
+
+
 @pytest.mark.parametrize("ttype", [list, tuple, pd.Index, pd.Series, np.array])
-def test_sequence_extract(ttype):
+def test_sequence_extract_multiple_names(ttype):
     data = ttype(VALUES)
     actual = resolve_io(data).extract(data, names=NAMES)
     assert actual == {n: [v] for n, v, in zip(NAMES, VALUES)}

--- a/tests/dio/test_insert.py
+++ b/tests/dio/test_insert.py
@@ -10,6 +10,18 @@ from .conftest import TRANSLATED, UNTRANSLATED
 NAME = "nconst"
 
 
+def test_dict_insert(translation_map):
+    expected = {"firstTitle": {TRANSLATED["firstTitle"][2]}, "nconst": TRANSLATED["nconst"].copy()}
+    dict_io = resolve_io(expected)
+
+    actual = {"firstTitle": {UNTRANSLATED["firstTitle"][2]}, "nconst": UNTRANSLATED["nconst"].copy()}
+    copied = dict_io.insert(actual, list(actual), translation_map, copy=True)
+    assert copied == expected
+
+    dict_io.insert(actual, list(actual), translation_map, copy=False)
+    assert actual == expected
+
+
 @pytest.mark.parametrize("ttype", [list, tuple, pd.Index, pd.Series, np.array])
 def test_sequence_insert(ttype, translation_map):
     actual, ans = _do_insert(translation_map, ttype, copy=True)
@@ -17,7 +29,7 @@ def test_sequence_insert(ttype, translation_map):
     _test_eq(actual, ttype(UNTRANSLATED[NAME]))
 
 
-@pytest.mark.parametrize("ttype", [list, pd.Series])
+@pytest.mark.parametrize("ttype", [list, pd.Series, set])
 def test_sequence_insert_inplace(ttype, translation_map):
     actual = ttype(UNTRANSLATED[NAME])
     translatable_io = resolve_io(actual)


### PR DESCRIPTION
- Add an _optional_ flag for fetchers in multi-fetcher mode.
  Allows discarding fetchers that cannot access their sources in the current environment.

- Improve and extend names handling
  - Allow `dict`-type `'names'`-argument
  - Catch `UntranslatableTypeError` when getting names from parent
  - Simplify `ignore_names`-logic

- Improve support for built-in types
  - Implement `set` translation
  - Handle heterogeneous `dict` value types

Various other under-the-good fixes.