### PR TITLE
Ensure that (un)translated IDs are never `None`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Return copy in `TranslationMap.name_to_source`
 - Handle `dict` names properly in `Translator.fetch()` and `go_offline()`.
+- Fixed a `maximal_untranslated_fraction`-related performance issue.
 
 ## [0.8.0] - 2024-03-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Return copy in `TranslationMap.name_to_source`
 - Handle `dict` names properly in `Translator.fetch()` and `go_offline()`.
 - Fixed a `maximal_untranslated_fraction`-related performance issue.
+- Untranslated IDs should now never be `None` - ensure a valid `Format` is always available.
 
 ## [0.8.0] - 2024-03-23
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,43 +11,14 @@ which demonstrates the (desired) usage.
 
 [minimal-reproducible-example]: https://stackoverflow.com/help/minimal-reproducible-example
 
-## PR guidelines
-To be merged, all tests (including generating documentation), must be successful.
-
-## Code requirements
-General requirements which applies to all code in the library.
-
-This is still a **pre-release library** (`version ~ 0.y.z`), meaning that breaking changes [are allowed](https://semver.org/#spec-item-4)
-without a major version bump. But ***be nice to downstream users*** anyway. Don't make major and hard-to-adapt-to
-breaking changes unless it makes sense and is needed.
-
-### Unchecked requirements
-These requirements are *not* verified in CI/CD.
-
-* User-facing changes should be recorded in the [changelog](https://github.com/rsundqvist/id-translation/blob/master/CHANGELOG.md).
-* Summarize the changes being made, and why they're made.
-* Expensive operations (especially related to logging) should only be done if the result is needed.
-* Coverage exceptions should be minimal.
-
-### Checked requirements
-These requirements are verified in CI/CD.
-
-* Coverage must remain at 100% (after ignores).
-* Public methods and classes must be documented.
-* Use the commit hooks to format and lint the code.
-
 ## Getting started
-Follow these steps to begin local development. I use Ubuntu LTS and PyCharm 
-(both are kept updated), so such environments will usually work without too much
-trouble.
+Follow these steps to begin local development.
 
-1. **Installing [Poetry](https://python-poetry.org/docs/) and [Invoke](https://www.pyinvoke.org/)**
+1. **Installing [Poetry](https://python-poetry.org/docs/)**
    
-   Poetry is a dependency management tool. You must have `poetry >= 1.2.2` as this project uses version 2.0 of the
-   lockfile  format.
+   See [poetry.lock](https://github.com/rsundqvist/id-translation/blob/master/poetry.lock) for the version used.
    ```bash
    curl -sSL https://install.python-poetry.org/ | python -
-   pip install invoke
    ```
 
 2. **Installing the project**
@@ -57,8 +28,7 @@ trouble.
    ```bash
    git clone --recurse-submodules git@github.com:rsundqvist/id-translation.git
    cd id-translation
-   git submodule update --init --recursive
-   poetry install --all-extras --with=docs,notebooks
+   poetry install --all-extras
    ```
    
    Generating documentation has a few dependencies which may need to be installed
@@ -68,23 +38,18 @@ trouble.
    sudo apt-get install pandoc tree
    ```
    
-3. **Install commit hooks (optional)**
+3. **Verify installation (optional)**
    
-   If this step is skipped, use `inv hooks` to run hooks manually.
-   ```bash
-   poetry run inv install-hooks
-   ```
-   
-4. **Verify installation (optional)**
-
-   This is similar to what the CI/CD pipeline will run for a single OS and major
-   Python version. It also skips the additional isolation provided by `nox`,
-   which may hide some dependency-gotchas.
+   Start the [test databases](https://hub.docker.com/r/rsundqvist/sakila-preload).
    ```bash
    ./run-docker-dvdrental.sh
-   ./run-invocations.sh
    ```
 
+   Run all invocations.
+   ```bash
+   ./run-invocations.sh
+   ```
+   This is similar to what the CI/CD pipeline does for a single OS and major Python version.
 
 ### Running GitHub Actions locally
 Relying on GitHub actions for new CI/CD features is quite slow. An alternative is to use 
@@ -99,11 +64,3 @@ will execute the [tests](https://github.com/rsundqvist/id-translation/blob/maste
 
 ## Branching point
 Branched from [rics@v1.0.0](https://github.com/rsundqvist/rics/tree/v1.0.0).
-
-## Source template
-Originally created with [Cookiecutter] and the [fedejaure/cookiecutter-modern-pypackage]
-template. The repo has changed quite a lot since creation, but some linked
-resources linked are still useful.
-
-[Cookiecutter]: https://github.com/cookiecutter/cookiecutter
-[fedejaure/cookiecutter-modern-pypackage]: https://github.com/fedejaure/cookiecutter-modern-pypackage

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2022, Richard Sundqvist
+Copyright (c) 2024, Richard Sundqvist
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ for multiple different SQL dialects and schema naming paradigms. The included TO
 support functions make it easy to create and share working configurations with anyone who needs them.
 
 # Cookiecutter template project
-The fastest way to get started with `id-translation` is the 🍪[id-translation-project] cookiecutter template. It is
+The fastest way to get started with `id-translation` is the 🍪[id-translation-project] Cookiecutter template. It is
 designed to allow power users to quickly specify shared configurations that "just work" for other users; see the example
 below.
 
@@ -46,23 +46,29 @@ Your generated project might look like, or continue to the next section for a br
 [id-translation-project]: https://github.com/rsundqvist/id-translation-project/
 
 # Highlighted Features
-- Support for ``int`` and ``string`` IDs, including ``UUID``-like types.
-- Translation of [pandas types][pandas-translation], including `pandas.Index` types.
-- Intuitive [Format strings][format], with support for optional elements.
-- Powerful automated [Name-to-source][n2s-mapping] and [Format placeholder][pm-mapping] mapping.
-- Prebuilt fetchers for [SQL][sql-fetcher] and [file-system][pandas-fetcher] sources.
-- Configure using [TOML][translator-config], support for [persistent] instances stored on disk.
+- Intuitive [Format strings] (modern `'{id}:{name}'` syntax), including support for
+  [Format Specification Mini-Language] features and extensions for optional keys.
+- Fetchers for [SQL] and local or remote [file-system] sources.
+- Powerful [Name-to-source] and [Placeholder-to-column] mapping and name extraction.
+- Configurable using [TOML] - see the 🍪[id-translation-project] Cookiecutter template.
+- Highly configurable interface: [Translator.translate()].
+
+[Format strings]: https://id-translation.readthedocs.io/en/stable/_autosummary/id_translation.offline.html#id_translation.offline.Format
+[Format Specification Mini-Language]: https://docs.python.org/3/library/string.html#formatspec
+[SQL]: https://id-translation.readthedocs.io/en/stable/_autosummary/id_translation.fetching.html#id_translation.fetching.SqlFetcher
+[file-system]: https://id-translation.readthedocs.io/en/stable/_autosummary/id_translation.fetching.html#id_translation.fetching.PandasFetcher
+[Name-to-source]: https://id-translation.readthedocs.io/en/stable/documentation/translation-primer.html#name-to-source-mapping
+[Placeholder-to-column]: https://id-translation.readthedocs.io/en/stable/documentation/translation-primer.html#placeholder-mapping
+[TOML]: https://id-translation.readthedocs.io/en/stable/documentation/translator-config.html
+[cached instances]: https://id-translation.readthedocs.io/en/stable/_autosummary/id_translation.Translator.load_persistent_instance.html
+[Translator.translate()]: https://id-translation.readthedocs.io/en/stable/_autosummary/id_translation.Translator.translate.html
+
+## Supported types
+- Supported ID types: `int`, `string`, and `UUID`.
+- Supports translation of build-in collections: `list`, `dict`, `set`, `tuple`.
+- Supports translation of [pandas types][pandas-translation], including `pandas.MultiIndex` types.
 
 [pandas-translation]: https://id-translation.readthedocs.io/en/stable/documentation/examples/notebooks/cookbook/pandas-index.html
-[translate]: https://id-translation.readthedocs.io/en/stable/_autosummary/id_translation.Translator.translate.html
-[format]: https://id-translation.readthedocs.io/en/stable/_autosummary/id_translation.offline.html#id_translation.offline.Format
-[n2s-mapping]: https://id-translation.readthedocs.io/en/stable/documentation/translation-primer.html#name-to-source-mapping
-[pm-mapping]: https://id-translation.readthedocs.io/en/stable/documentation/translation-primer.html#placeholder-mapping
-[persistent]: https://id-translation.readthedocs.io/en/stable/_autosummary/id_translation.Translator.load_persistent_instance.html
-[sql-fetcher]: https://id-translation.readthedocs.io/en/stable/_autosummary/id_translation.fetching.html#id_translation.fetching.SqlFetcher
-[pandas-fetcher]: https://id-translation.readthedocs.io/en/stable/_autosummary/id_translation.fetching.html#id_translation.fetching.PandasFetcher
-[translator-config]: https://id-translation.readthedocs.io/en/stable/documentation/translator-config.html
-
 
 # Installation
 The package is published through the [Python Package Index (PyPI)]. Source code

--- a/src/id_translation/_translator.py
+++ b/src/id_translation/_translator.py
@@ -74,8 +74,6 @@ if TYPE_CHECKING:
 
     ID_TRANSLATION_PANDAS_IS_TYPED: bool = False
 
-DEFAULT_FORMAT = Format("<Failed: id={id!r}>")
-
 
 class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
     """End-user interface for all translation tasks.
@@ -142,9 +140,9 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
     def __init__(
         self,
         fetcher: FetcherTypes[NameType, SourceType, IdType] | None = None,
-        fmt: FormatType = "{id}:{name}",
+        fmt: FormatType = Format.DEFAULT,
         mapper: Mapper[NameType, SourceType, None] = None,
-        default_fmt: FormatType = DEFAULT_FORMAT,
+        default_fmt: FormatType = Format.DEFAULT_FAILED,
         default_fmt_placeholders: MakeType[SourceType, str, Any] | None = None,
         enable_uuid_heuristics: bool = False,
         transformers: dict[SourceType, Transformer[IdType]] | None = None,
@@ -153,9 +151,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
 
         self._fmt = fmt if isinstance(fmt, Format) else Format(fmt)
         self._default_fmt_placeholders: InheritedKeysDict[SourceType, str, Any] | None
-        self._default_fmt_placeholders, self._default_fmt = _handle_default(
-            self._fmt, default_fmt, default_fmt_placeholders
-        )
+        self._default_fmt_placeholders, self._default_fmt = _handle_default(default_fmt, default_fmt_placeholders)
         self._enable_uuid_heuristics = enable_uuid_heuristics
 
         self._cached_tmap: TranslationMap[NameType, SourceType, IdType] = TranslationMap({})
@@ -1260,10 +1256,9 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
 
 
 def _handle_default(
-    fmt: Format,
     default_fmt: FormatType,
     default_fmt_placeholders: MakeType[SourceType, str, Any] | None,
-) -> tuple[InheritedKeysDict[SourceType, str, Any] | None, Format | None]:  # pragma: no cover
+) -> tuple[InheritedKeysDict[SourceType, str, Any], Format]:
     default_fmt = Format.parse(default_fmt)
 
     if not default_fmt_placeholders:
@@ -1274,4 +1269,4 @@ def _handle_default(
     else:
         default_placeholders = InheritedKeysDict.make(default_fmt_placeholders)
 
-    return default_placeholders, fmt if default_fmt is DEFAULT_FORMAT else default_fmt
+    return default_placeholders, default_fmt

--- a/src/id_translation/_translator.py
+++ b/src/id_translation/_translator.py
@@ -183,7 +183,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             tmap = fetcher.copy()
             tmap.fmt = self._fmt
             tmap.default_fmt = self._default_fmt
-            tmap.default_fmt_placeholders = self._default_fmt_placeholders  # type: ignore
+            tmap.default_fmt_placeholders = self._default_fmt_placeholders
             self._cached_tmap = tmap
         else:
             raise TypeError(type(fetcher))  # pragma: no cover

--- a/src/id_translation/_uuid_utils.py
+++ b/src/id_translation/_uuid_utils.py
@@ -9,9 +9,6 @@ IdCollectionT = TypeVar("IdCollectionT", bound=Sequence)  # type: ignore[type-ar
 
 def cast_many(ids: IdCollectionT) -> IdCollectionT:
     """Cast `ids` to UUIDs."""
-    if isinstance(ids[0], UUID):
-        return ids
-
     uuids = map(UUID, ids)
     if isinstance(ids, np.ndarray):
         return np.fromiter(uuids, dtype=UUID)
@@ -21,7 +18,7 @@ def cast_many(ids: IdCollectionT) -> IdCollectionT:
 
 def try_cast_many(ids: IdCollectionT) -> IdCollectionT:
     """Try casting `ids` to UUIDs, falling back to the original input."""
-    if not ids:
+    if len(ids) == 0:
         return ids
 
     try:

--- a/src/id_translation/dio/_pandas.py
+++ b/src/id_translation/dio/_pandas.py
@@ -94,7 +94,7 @@ def _translate_pandas_vector(
         if is_numeric_dtype(pvt):
             # We don't need to cast float to int here, since hash(1.0) == hash(1). The cast in extract() is required
             # because some database drivers may complain, especially if they receive floats (especially NaN).
-            mapping = {idx: magic_dict.get(idx) for idx in pvt.unique()}
+            mapping = {idx: magic_dict[idx] for idx in pvt.unique()}
             return pvt.map(mapping)
         else:
             mapping = {}
@@ -103,7 +103,7 @@ def _translate_pandas_vector(
                 if idx in mapping:
                     value = mapping[idx]
                 else:
-                    value = magic_dict.get(idx)
+                    value = magic_dict[idx]
                     mapping[idx] = value
                 data[i] = value
 

--- a/src/id_translation/dio/_sequence.py
+++ b/src/id_translation/dio/_sequence.py
@@ -50,17 +50,16 @@ class SequenceIO(DataStructureIO):
             raise NotInplaceTranslatableError(translatable) from e
 
 
-def translate_sequence(
-    s: T, names: list[NameType], tmap: TranslationMap[NameType, SourceType, IdType]
-) -> list[str | None]:
+def translate_sequence(s: T, names: list[NameType], tmap: TranslationMap[NameType, SourceType, IdType]) -> list[str]:
     """Return a translated copy of the sequence `s`."""
     if len(names) == 1:
-        return list(map(tmap[names[0]].get, s))
+        magic_dict = tmap[names[0]]
+        return [magic_dict[i] for i in s]
 
     return [
         translate_sequence(element, [name], tmap)  # type: ignore
         if SequenceIO.handles_type(element)
-        else tmap[name].get(element)
+        else tmap[name][element]
         for name, element in zip(names, s)
     ]
 

--- a/src/id_translation/dio/_set.py
+++ b/src/id_translation/dio/_set.py
@@ -23,9 +23,9 @@ class SetIO(DataStructureIO):
     @staticmethod
     def insert(
         translatable: set[IdType], names: list[NameType], tmap: TranslationMap[NameType, SourceType, IdType], copy: bool
-    ) -> set[str | None] | None:
+    ) -> set[str] | None:
         magic_dict = tmap[names[0]]
-        translated = {magic_dict.get(e) for e in translatable}
+        translated = {magic_dict[e] for e in translatable}
 
         if copy:
             return translated

--- a/src/id_translation/offline/_format.py
+++ b/src/id_translation/offline/_format.py
@@ -8,7 +8,7 @@ from .types import FormatType, PlaceholdersTuple
 
 
 class Format:
-    r"""Format specification for translations strings.
+    """Format specification for translations strings.
 
     Translation formats are similar to regular f-strings, with two important exceptions:
 
@@ -28,6 +28,40 @@ class Format:
         fmt: A translation fstring.
 
     Examples:
+        **Basic usage**
+
+        Formats are created by passing a single ``str`` arguments, as described above.
+
+        >>> Format(Format.DEFAULT)
+        "Format('{id}:{name}')"
+        >>> Format(Format.DEFAULT).fstring().format(id=1, name="First")
+        '1:First'
+
+        Using :meth:`Format.fstring` and :py:meth:`str.format` is flexible but verbose. Formats can be applier either
+        through :meth:`Format.format`...
+
+        >>> fmt = Format(Format.DEFAULT_FAILED)
+        >>> fmt.format(id=1, name="First")
+
+        ...or just ``Format.__call__()``.
+
+        >>> fmt(id=1, name="First")
+        '<Failed: id=1>'
+
+        Using either convenience method will use as many placeholders as possible.
+
+        >>> fmt = Format(Format.DEFAULT)
+        >>> fmt.placeholders
+        "('id', 'name')"
+        >>> fmt(id=1, name="First")
+        '1:First'
+        >>> fmt(id=1, name="First", unknown=20.19)
+        '1:First'
+
+        Unknown placeholders are simply ignored.
+
+        **Optional placeholders**
+
         A format string using literal angle brackets and an optional element.
 
         >>> from id_translation.offline import Format
@@ -37,14 +71,14 @@ class Format:
 
         >>> fmt.fstring()
         '{id}:[{name}]'
-        >>> fmt.fstring().format(id=0, name="Tarzan")
+        >>> fmt(id=0, name="Tarzan")
         '0:[Tarzan]'
 
         ...but the :attr:`placeholders` attribute can be used to retrieve all placeholders, required and optional:
 
         >>> fmt.placeholders
         ('id', 'name', 'is_nice')
-        >>> fmt.fstring(fmt.placeholders).format(id=1, name="Morris", is_nice=True)
+        >>> fmt(id=1, name="Morris", is_nice=True)
         '1:[Morris], nice=True'
 
     The :class:`.Translator` will automatically add optional placeholders, if they are present in the source.
@@ -59,15 +93,34 @@ class Format:
 
     Convert to string and truncate to eight characters.
 
-    >>> Format("{id!s:.8}:{name!r}").fstring().format(id=uuid, name="Sofia")
+    >>> Format("{id!s:.8}:{name!r}").format(id=uuid, name="Sofia")
     "550e8400:'Sofia'"
 
     See the official :py:ref:`formatspec` documentation for details.
     """
 
+    DEFAULT: str = "{id}:{name}"
+    """Default translation format."""
+
+    DEFAULT_FAILED: str = "<Failed: id={id!r}>"
+    """Default format for missing IDs."""
+
     def __init__(self, fmt: str) -> None:
         self._fmt = fmt
         self._elements: list[parse_format_string.Element] = parse_format_string.get_elements(fmt)
+
+    def format(self, **placeholders: Any) -> str:
+        """Apply the format.
+
+        Args:
+            **placeholders: Formats to use in the finals string.
+
+        Returns:
+            Formatting using `placeholders`.
+        """
+        return self.fstring(placeholders, positional=False).format_map(placeholders)
+
+    __call__ = format
 
     def fstring(self, placeholders: Iterable[str] | None = None, *, positional: bool = False) -> str:
         """Create a format string for the given placeholders.

--- a/src/id_translation/offline/_format_applier.py
+++ b/src/id_translation/offline/_format_applier.py
@@ -36,8 +36,9 @@ class FormatApplier(Generic[NameType, SourceType, IdType]):
     def __call__(
         self,
         fmt: Format,
-        placeholders: PlaceholdersTuple = None,
-        default_fmt: Format = None,
+        *,
+        default_fmt: Format,
+        placeholders: PlaceholdersTuple | None = None,
         default_fmt_placeholders: dict[str, Any] | None = None,
         enable_uuid_heuristics: bool = True,
     ) -> MagicDict[IdType]:
@@ -60,22 +61,17 @@ class FormatApplier(Generic[NameType, SourceType, IdType]):
         fstring = fmt.fstring(placeholders, positional=True)
         real_translations = self._apply(fstring, placeholders)
 
-        if default_fmt is not None or default_fmt_placeholders is not None:
-            if default_fmt is None:
-                default_fmt = fmt
-            if default_fmt_placeholders is None:
-                default_fmt_placeholders = {}
+        if default_fmt_placeholders is None:
+            default_fmt_placeholders = {}
 
-            partial = default_fmt.partial(default_fmt_placeholders)
-            try:
-                default_fstring = partial.fstring(positional=True)
-            except KeyError as e:
-                raise ValueError(
-                    f"All required placeholders except {{{ID}}} must be provided for {default_fmt=}:"
-                    f" {default_fmt.required_placeholders}."
-                ) from e
-        else:
-            default_fstring = None
+        partial = default_fmt.partial(default_fmt_placeholders)
+        try:
+            default_fstring = partial.fstring(positional=True)
+        except KeyError as e:
+            raise ValueError(
+                f"All required placeholders except {{{ID}}} must be provided for {default_fmt=}:"
+                f" {default_fmt.required_placeholders}."
+            ) from e
 
         return MagicDict(real_translations, default_fstring, enable_uuid_heuristics, self._transformer)
 

--- a/src/id_translation/types.py
+++ b/src/id_translation/types.py
@@ -10,8 +10,6 @@ Rules of thumb
 * Non-inplace (copy-translation, default) always `tries` to return a collection of the same type, with all
   :attr:`IdTypes` converted to :py:class:`str`.
 * In-place translation always returns ``None``, or raises :class:`~.dio.exceptions.NotInplaceTranslatableError`.
-* When ``default_fmt=None``, IDs may be replaced by ``None`` as well (contrary to type hints).
-* Translating with ``maximal_untranslated_fraction=0`` guarantees that IDs are never replaced with ``None``.
 
 Overloads err on the overly-permissive side. Static type checkers (only MyPy is tested) may incorrectly allow things
 like ``translator.translate("a-string-id")`` for ``int``-only ``Translator`` instances.
@@ -21,7 +19,6 @@ Limitations
 Python does not support generics-of-generics, which is the primary domain in which the ``Translator.translate``-method
 operates. See https://github.com/python/typing/issues/548 for details on this subject.
 
-* Reverse-mode translation (``reverse=True``) is not type-hinted.
 * Numpy is supported, but not typed.
 * Pandas typing must be enabled using the ``ID_TRANSLATION_PANDAS_IS_TYPED``-flag.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,12 +11,19 @@ from id_translation.fetching import AbstractFetcher
 from id_translation.fetching.exceptions import UnknownIdError
 from id_translation.fetching.types import FetchInstruction
 from id_translation.mapping import Mapper
-from id_translation.offline import TranslationMap
+from id_translation.offline import MagicDict, TranslationMap
 from id_translation.offline.types import PlaceholderTranslations
 
 ROOT: Path = Path(__file__).parent
 
 Mapper.__init__ = partialmethod(Mapper.__init__, verbose_logging=True)  # type: ignore[assignment]
+
+
+def dont_call_get(*_, **__):
+    raise AssertionError("MagicDict.get is inefficient.")
+
+
+MagicDict.get = dont_call_get  # type: ignore[method-assign]
 
 
 class CheckSerializeToJson(logging.Handler):

--- a/tests/offline/test_format.py
+++ b/tests/offline/test_format.py
@@ -33,8 +33,9 @@ def test_format(fmt, translations, expected):
 
 
 def test_missing_required(fmt):
-    with pytest.raises(KeyError):
-        fmt.fstring(("does", "not", "exist"))
+    with pytest.raises(KeyError) as e:
+        fmt(name="Foo")
+    assert str(e.value.args[0]) == "Required key(s) {'id'} missing from placeholders={'name': 'Foo'}."
 
 
 @pytest.mark.parametrize(

--- a/tests/offline/test_format_applier.py
+++ b/tests/offline/test_format_applier.py
@@ -10,7 +10,7 @@ def fmt():
 
 def test_no_explicit_placeholders(fmt):
     translations = PlaceholderTranslations("source", ("id", "baz", "foo"), [(1, 1, 3), (2, 2, 4)], 0)
-    applier: FormatApplier[str, str, int] = FormatApplier(translations)
+    applier = FormatApplier[str, str, int](translations)
 
     ans = applier(fmt)
     assert ans == {1: "3 1: baz=1", 2: "4 2: baz=2"}
@@ -18,7 +18,7 @@ def test_no_explicit_placeholders(fmt):
 
 def test_explicit_placeholders(fmt):
     translations = PlaceholderTranslations("source", ("id", "baz", "foo"), [(1, 1, 3), (2, 2, 4)], 0)
-    applier: FormatApplier[str, str, int] = FormatApplier(translations)
+    applier = FormatApplier[str, str, int](translations)
 
     ans = applier(fmt, ("foo", "id"), default_fmt_placeholders={"baz": "default-baz", "foo": "default-baz"})
     assert ans == {1: "3 1", 2: "4 2"}

--- a/tests/offline/test_format_applier.py
+++ b/tests/offline/test_format_applier.py
@@ -12,7 +12,7 @@ def test_no_explicit_placeholders(fmt):
     translations = PlaceholderTranslations("source", ("id", "baz", "foo"), [(1, 1, 3), (2, 2, 4)], 0)
     applier = FormatApplier[str, str, int](translations)
 
-    ans = applier(fmt)
+    ans = applier(fmt, default_fmt=Format(""))
     assert ans == {1: "3 1: baz=1", 2: "4 2: baz=2"}
 
 
@@ -20,5 +20,10 @@ def test_explicit_placeholders(fmt):
     translations = PlaceholderTranslations("source", ("id", "baz", "foo"), [(1, 1, 3), (2, 2, 4)], 0)
     applier = FormatApplier[str, str, int](translations)
 
-    ans = applier(fmt, ("foo", "id"), default_fmt_placeholders={"baz": "default-baz", "foo": "default-baz"})
+    ans = applier(
+        fmt,
+        default_fmt=Format(""),
+        placeholders=("foo", "id"),
+        default_fmt_placeholders={"baz": "default-baz", "foo": "default-baz"},
+    )
     assert ans == {1: "3 1", 2: "4 2"}

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -396,7 +396,7 @@ def test_reverse(hex_fetcher):
 
     actual = translator.translate(translated, reverse=True)
     assert_type(actual, dict[str, list[int]])  # type: ignore[assert-type]  # Overloads are incomplete for reverse=True
-    assert actual == {"positive_numbers": [None, 0, 1]}, "Original format"
+    assert actual == {"positive_numbers": ["<Failed: id='<Failed: id=-1>'>", 0, 1]}, "Original format"
 
     with pytest.raises(TooManyFailedTranslationsError, match=r"Sample IDs: \['<Failed: id=-1>'\]"):
         translator.translate(translated, reverse=True, maximal_untranslated_fraction=0)


### PR DESCRIPTION
* Update README.md and CONTRIBUTING.md
* Multiple signature updates to ensure that there's always a valid `Format` to fall back on.
* Moved default `str` constants to the `Format` class + convenience methods showcased in docstring
* Bonus content: `maximal_untranslated_fraction` performance uplift and 