### PR TITLE
Rename params

### DIFF
--- a/docs/documentation/examples/resources/dvdrental.py
+++ b/docs/documentation/examples/resources/dvdrental.py
@@ -59,5 +59,5 @@ print(translator)
 
 print(translator.map(df))
 
-translator.translate(df, inplace=True)
+translator.translate(df, copy=False)
 print(df.loc[sample.index])

--- a/docs/documentation/translation-primer.rst
+++ b/docs/documentation/translation-primer.rst
@@ -236,7 +236,7 @@ Putting it all together
    translator = Translator(fetcher, fmt=translation_format, mapper=mapper)
    translated_bite_report = translator.translate(bite_report)
 
-Unless ``inplace=True`` is passed :meth:`~Translator.translate`, always returns a copy.
+Unless ``copy=False`` is passed :meth:`~Translator.translate`, always returns a copy.
 
 Translated data
 ---------------

--- a/docs/documentation/translator-config.rst
+++ b/docs/documentation/translator-config.rst
@@ -79,7 +79,7 @@ Section: Unknown IDs
 .. note::
 
    Sources that are translated using default placeholders count as successful translations when using
-   :meth:`Translator.translate(maximal_untranslated_fraction != 1) <.Translator.translate>`.
+   :meth:`Translator.translate(max_fails != 1) <.Translator.translate>`.
 
 .. _translator-config-transform:
 

--- a/docs/generate-dvdrental-logs.py
+++ b/docs/generate-dvdrental-logs.py
@@ -81,7 +81,7 @@ def main():
     df = pd.DataFrame.from_records(records, columns=expected.columns).loc[expected.index]
 
     with enable_verbose_debug_messages():
-        translator.translate(df, inplace=True)
+        translator.translate(df, copy=False)
 
     pd.testing.assert_frame_equal(df, expected)
 

--- a/src/id_translation/_compat.py
+++ b/src/id_translation/_compat.py
@@ -1,8 +1,12 @@
 """Vendored functions."""
 
+from functools import wraps
 from os import PathLike
 from pathlib import Path
-from typing import TypeAlias
+from typing import Callable, ParamSpec, TypeAlias, TypeVar
+from warnings import warn
+
+from rics.misc import tname
 
 # TODO(0.11.0): any_path_to_path(p, postprocessor=...)
 PathLikeType: TypeAlias = str | PathLike[str] | Path
@@ -19,3 +23,42 @@ except ImportError:
     # TODO(0.11.0): Drop this.
     fmt_perf = performance.format_perf_counter
     fmt_sec = performance.format_seconds
+
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+PARAMS = (
+    ("copy", "inplace"),
+    # ("max_fails", "maximal_untranslated_fraction"),
+)
+WARNED: set[str] = set()  # Minimize the amount of warnings - once per param is enough.
+
+
+def deprecated_params(__func: Callable[P, T], /) -> Callable[P, T]:
+    @wraps(__func)
+    def wrap(*args: P.args, **kwargs: P.kwargs) -> T:
+        for new, old in PARAMS:
+            if old in kwargs:
+                if new in kwargs:
+                    name = tname(__func, prefix_classname=True)
+                    msg = f"Ambiguous call: {name}() does not accept both `{old}` and `{new}`."
+                    raise TypeError(msg)
+
+                if old not in WARNED:
+                    WARNED.add(old)
+
+                    name = tname(__func, prefix_classname=True)
+                    msg = f"{name}(): The `{old}` parameter is deprecated; use `{new}` instead."
+                    warn(message=msg, category=DeprecationWarning, stacklevel=2)
+
+                value = kwargs.pop(old)
+
+                if old == "inplace":
+                    value = not value
+
+                kwargs[new] = value
+
+        return __func(*args, **kwargs)
+
+    return wrap

--- a/src/id_translation/_compat.py
+++ b/src/id_translation/_compat.py
@@ -30,7 +30,7 @@ T = TypeVar("T")
 
 PARAMS = (
     ("copy", "inplace"),
-    # ("max_fails", "maximal_untranslated_fraction"),
+    ("max_fails", "maximal_untranslated_fraction"),
 )
 WARNED: set[str] = set()  # Minimize the amount of warnings - once per param is enough.
 

--- a/src/id_translation/_translator.py
+++ b/src/id_translation/_translator.py
@@ -23,7 +23,7 @@ from rics.collections.dicts import InheritedKeysDict, MakeType
 from rics.collections.misc import as_list
 from rics.misc import get_public_module, tname
 
-from id_translation._compat import PathLikeType, fmt_perf
+from id_translation._compat import PathLikeType, deprecated_params, fmt_perf
 
 from ._tasks import MappingTask, TranslationTask, generate_task_id
 from .exceptions import ConnectionStatusError, TranslationDisabledWarning
@@ -273,7 +273,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             names: NameTypes[NameType] | NameToSource[NameType, SourceType] | None = None,
             *,
             # https://github.com/python/mypy/issues/7333#issuecomment-788255229
-            inplace: Literal[True],
+            copy: Literal[False],
             ignore_names: Names[NameType] | None = None,
             override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
             maximal_untranslated_fraction: float = 1.0,
@@ -289,7 +289,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             names: NameTypes[NameType] | NameToSource[NameType, SourceType] | None = None,
             *,
             # https://github.com/python/mypy/issues/7333#issuecomment-788255229
-            inplace: Literal[True],
+            copy: Literal[False],
             ignore_names: Names[NameType] | None = None,
             override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
             maximal_untranslated_fraction: float = 1.0,
@@ -304,7 +304,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             translatable: IdTypes,
             names: NameTypes[NameType] | NameToSource[NameType, SourceType] | None = None,
             *,
-            inplace: Literal[False] = False,
+            copy: Literal[True] = True,
             ignore_names: Names[NameType] | None = None,
             override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
             maximal_untranslated_fraction: float = 1.0,
@@ -319,7 +319,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             translatable: list[IdType],
             names: NameTypes[NameType] | NameToSource[NameType, SourceType] | None = None,
             *,
-            inplace: Literal[False] = False,
+            copy: Literal[True] = True,
             ignore_names: Names[NameType] | None = None,
             override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
             maximal_untranslated_fraction: float = 1.0,
@@ -336,7 +336,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
         #     translatable: List[List[IdType]],
         #     names: Union[NameTypes[NameType], NameToSource[NameType, SourceType]] = None,
         #     *,
-        #     inplace: Literal[False] = False,
+        #     copy: Literal[True] = True,
         #     ignore_names: Names[NameType] | None = None,
         #     override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
         #     maximal_untranslated_fraction: float = 1.0,
@@ -352,7 +352,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             translatable: set[IdType],
             names: NameTypes[NameType] | NameToSource[NameType, SourceType] | None = None,
             *,
-            inplace: Literal[False] = False,
+            copy: Literal[True] = True,
             ignore_names: Names[NameType] | None = None,
             override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
             maximal_untranslated_fraction: float = 1.0,
@@ -370,7 +370,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             translatable: DictToId[NameType, int] | DictToId[NameType, str] | DictToId[NameType, UUID],
             names: NameTypes[NameType] | NameToSource[NameType, SourceType] | None = None,
             *,
-            inplace: Literal[False] = False,
+            copy: Literal[True] = True,
             ignore_names: Names[NameType] | None = None,
             override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
             maximal_untranslated_fraction: float = 1.0,
@@ -385,7 +385,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             translatable: DictToSet[NameType, IdType],
             names: NameTypes[NameType] | NameToSource[NameType, SourceType] | None = None,
             *,
-            inplace: Literal[False] = False,
+            copy: Literal[True] = True,
             ignore_names: Names[NameType] | None = None,
             override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
             maximal_untranslated_fraction: float = 1.0,
@@ -400,7 +400,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             translatable: DictToList[NameType, IdType],
             names: NameTypes[NameType] | NameToSource[NameType, SourceType] | None = None,
             *,
-            inplace: Literal[False] = False,
+            copy: Literal[True] = True,
             ignore_names: Names[NameType] | None = None,
             override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
             maximal_untranslated_fraction: float = 1.0,
@@ -415,7 +415,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             translatable: DictToOneTuple[NameType, IdType],
             names: NameTypes[NameType] | NameToSource[NameType, SourceType] | None = None,
             *,
-            inplace: Literal[False] = False,
+            copy: Literal[True] = True,
             ignore_names: Names[NameType] | None = None,
             override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
             maximal_untranslated_fraction: float = 1.0,
@@ -430,7 +430,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             translatable: DictToTwoTuple[NameType, IdType],
             names: NameTypes[NameType] | NameToSource[NameType, SourceType] | None = None,
             *,
-            inplace: Literal[False] = False,
+            copy: Literal[True] = True,
             ignore_names: Names[NameType] | None = None,
             override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
             maximal_untranslated_fraction: float = 1.0,
@@ -445,7 +445,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             translatable: DictToThreeTuple[NameType, IdType],
             names: NameTypes[NameType] | NameToSource[NameType, SourceType] | None = None,
             *,
-            inplace: Literal[False] = False,
+            copy: Literal[True] = True,
             ignore_names: Names[NameType] | None = None,
             override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
             maximal_untranslated_fraction: float = 1.0,
@@ -460,7 +460,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             translatable: DictToVarTuple[NameType, IdType],
             names: NameTypes[NameType] | NameToSource[NameType, SourceType] | None = None,
             *,
-            inplace: Literal[False] = False,
+            copy: Literal[True] = True,
             ignore_names: Names[NameType] | None = None,
             override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
             maximal_untranslated_fraction: float = 1.0,
@@ -475,7 +475,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             translatable: tuple[IdType],
             names: NameTypes[NameType] | NameToSource[NameType, SourceType] | None = None,
             *,
-            inplace: Literal[False] = False,
+            copy: Literal[True] = True,
             ignore_names: Names[NameType] | None = None,
             override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
             maximal_untranslated_fraction: float = 1.0,
@@ -490,7 +490,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             translatable: tuple[IdType, IdType],
             names: NameTypes[NameType] | NameToSource[NameType, SourceType] | None = None,
             *,
-            inplace: Literal[False] = False,
+            copy: Literal[True] = True,
             ignore_names: Names[NameType] | None = None,
             override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
             maximal_untranslated_fraction: float = 1.0,
@@ -505,7 +505,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             translatable: tuple[IdType, IdType, IdType],
             names: NameTypes[NameType] | NameToSource[NameType, SourceType] | None = None,
             *,
-            inplace: Literal[False] = False,
+            copy: Literal[True] = True,
             ignore_names: Names[NameType] | None = None,
             override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
             maximal_untranslated_fraction: float = 1.0,
@@ -520,7 +520,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             translatable: tuple[IdType, ...],
             names: NameTypes[NameType] | NameToSource[NameType, SourceType] | None = None,
             *,
-            inplace: Literal[False] = False,
+            copy: Literal[True] = True,
             ignore_names: Names[NameType] | None = None,
             override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
             maximal_untranslated_fraction: float = 1.0,
@@ -538,7 +538,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
                 translatable: "pandas.DataFrame",
                 names: NameTypes[NameType] | NameToSource[NameType, SourceType] | None = None,
                 *,
-                inplace: Literal[False] = False,
+                copy: Literal[True] = True,
                 ignore_names: Names[NameType] | None = None,
                 override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
                 maximal_untranslated_fraction: float = 1.0,
@@ -553,7 +553,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
                 translatable: "pandas.Series[Any]",
                 names: NameTypes[NameType] | NameToSource[NameType, SourceType] | None = None,
                 *,
-                inplace: Literal[False] = False,
+                copy: Literal[True] = True,
                 ignore_names: Names[NameType] | None = None,
                 override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
                 maximal_untranslated_fraction: float = 1.0,
@@ -568,7 +568,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
                 translatable: "pandas.Index[Any]",
                 names: NameTypes[NameType] | NameToSource[NameType, SourceType] | None = None,
                 *,
-                inplace: Literal[False] = False,
+                copy: Literal[True] = True,
                 ignore_names: Names[NameType] | None = None,
                 override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
                 maximal_untranslated_fraction: float = 1.0,
@@ -583,7 +583,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
                 translatable: Union["pandas.DataFrame", "pandas.Series[Any]"],
                 names: NameTypes[NameType] | NameToSource[NameType, SourceType] | None = None,
                 *,
-                inplace: Literal[True],
+                copy: Literal[False],
                 ignore_names: Names[NameType] | None = None,
                 override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
                 maximal_untranslated_fraction: float = 1.0,
@@ -599,7 +599,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
                 names: NameTypes[NameType] | NameToSource[NameType, SourceType] | None = None,
                 *,
                 # https://github.com/python/mypy/issues/7333#issuecomment-788255229
-                inplace: Literal[True],
+                copy: Literal[False],
                 ignore_names: Names[NameType] | None = None,
                 override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
                 maximal_untranslated_fraction: float = 1.0,
@@ -615,10 +615,10 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             names: NameTypes[NameType] | NameToSource[NameType, SourceType] | None = None,
             *,
             ignore_names: Names[NameType] | None = None,
-            inplace: Literal[False] = False,
+            copy: Literal[True] = True,
             override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
             maximal_untranslated_fraction: float = 1.0,
-            reverse: Literal[False] = False,
+            reverse: Literal[True] = True,
             fmt: FormatType | None = None,
         ) -> Translatable[NameType, str]: ...
 
@@ -629,20 +629,21 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             names: NameTypes[NameType] | NameToSource[NameType, SourceType] | None = None,
             *,
             ignore_names: Names[NameType] | None = None,
-            inplace: Literal[False] = False,
+            copy: Literal[True] = True,
             override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
             maximal_untranslated_fraction: float = 1.0,
             reverse: Literal[True] = True,
             fmt: FormatType | None = None,
         ) -> Translatable[NameType, IdType]: ...
 
+    @deprecated_params
     def translate(
         self,
         translatable: Translatable[NameType, IdType],
         names: NameTypes[NameType] | NameToSource[NameType, SourceType] | None = None,
         *,
         ignore_names: Names[NameType] | None = None,
-        inplace: bool = False,
+        copy: bool = True,
         override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
         maximal_untranslated_fraction: float = 1.0,
         reverse: bool = False,
@@ -666,7 +667,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             names: Explicit names to translate. Derive from `translatable` if ``None``. Alternatively, you may pass a
                 ``dict`` on the form ``{name_in_translatable: source_to_use}``.
             ignore_names: Names **not** to translate, or a predicate ``(NameType) -> bool``.
-            inplace: If ``True``, translate in-place and return ``None``.
+            copy: If ``False``, translate in-place and return ``None``.
             override_function: A callable ``(name, sources, ids) -> Source | None``. See :meth:`.Mapper.apply`
                 for details.
             maximal_untranslated_fraction: The maximum fraction of IDs for which translation may fail. 1=disabled.
@@ -674,7 +675,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             fmt: A :class:`format string <.Format>` such as **'{id}:{name}'** use. Default is :attr:`.Translator.fmt`.
 
         Returns:
-            A translated copy of `translatable` if ``inplace=False``, otherwise ``None``.
+            A translated copy of `translatable` if ``copy=True``, otherwise ``None``.
 
         Examples:
             Manual `name-to-source <../documentation/translation-primer.html#name-to-source-mapping>`__ mapping with a
@@ -706,7 +707,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             LOGGER.warning(message)
             warnings.warn(message, category=TranslationDisabledWarning, stacklevel=2)
             # Return unchanged; this is technically against the API spec.
-            return None if inplace else translatable
+            return translatable if copy else None
 
         if self.online and reverse:  # pragma: no cover
             raise ConnectionStatusError("Reverse translation cannot be performed online.")
@@ -718,7 +719,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             names,
             ignore_names=ignore_names,
             override_function=override_function,
-            inplace=inplace,
+            copy=copy,
             maximal_untranslated_fraction=maximal_untranslated_fraction,
             reverse=reverse,
             enable_uuid_heuristics=self._enable_uuid_heuristics,
@@ -730,7 +731,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             # Return unchanged; this is technically against the API spec. If the user has required translation to
             # success through configuration, exceptions will be raised elsewhere. I don't know how to express this using
             # the Python type system.
-            return None if inplace else translatable
+            return translatable if copy else None
 
         task.verify(translation_map)
 
@@ -748,7 +749,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
 
     def translated_names(
         self,
-        with_source: bool | Literal[True] | Literal[False] = False,  # https://github.com/python/mypy/issues/14764
+        with_source: bool | Literal[True] | Literal[True] = True,  # https://github.com/python/mypy/issues/14764
     ) -> NameToSource[NameType, SourceType] | list[NameType]:
         """Return the names that were translated by the most recent :meth:`.translate`-call.
 

--- a/src/id_translation/_translator.py
+++ b/src/id_translation/_translator.py
@@ -89,7 +89,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
         default_fmt_placeholders: Shared and/or source-specific default placeholder values for unknown IDs. See
             :meth:`rics.collections.dicts.InheritedKeysDict.make` for details. Sources that are translated using default
             placeholders count as successful translations when using
-            :meth:`Translator.translate(maximal_untranslated_fraction != 1) <.Translator.translate>`.
+            :meth:`Translator.translate(max_fails != 1) <.Translator.translate>`.
         enable_uuid_heuristics: Enabling may improve matching when :py:class:`~uuid.UUID`-like IDs are in use.
         transformers: A dict ``{source: transformer}`` of initialized :class:`.Transformer` instances.
 
@@ -276,7 +276,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             copy: Literal[False],
             ignore_names: Names[NameType] | None = None,
             override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
-            maximal_untranslated_fraction: float = 1.0,
+            max_fails: float = 1.0,
             # Translation specification
             reverse: bool = False,
             fmt: FormatType | None = None,
@@ -292,7 +292,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             copy: Literal[False],
             ignore_names: Names[NameType] | None = None,
             override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
-            maximal_untranslated_fraction: float = 1.0,
+            max_fails: float = 1.0,
             # Translation specification
             reverse: bool = False,
             fmt: FormatType | None = None,
@@ -307,7 +307,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             copy: Literal[True] = True,
             ignore_names: Names[NameType] | None = None,
             override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
-            maximal_untranslated_fraction: float = 1.0,
+            max_fails: float = 1.0,
             # Translation specification
             reverse: bool = False,
             fmt: FormatType | None = None,
@@ -322,7 +322,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             copy: Literal[True] = True,
             ignore_names: Names[NameType] | None = None,
             override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
-            maximal_untranslated_fraction: float = 1.0,
+            max_fails: float = 1.0,
             # Translation specification
             reverse: bool = False,
             fmt: FormatType | None = None,
@@ -339,7 +339,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
         #     copy: Literal[True] = True,
         #     ignore_names: Names[NameType] | None = None,
         #     override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
-        #     maximal_untranslated_fraction: float = 1.0,
+        #     max_fails: float = 1.0,
         #     # Translation specification
         #     reverse: bool = False,
         #     fmt: FormatType | None = None,
@@ -355,7 +355,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             copy: Literal[True] = True,
             ignore_names: Names[NameType] | None = None,
             override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
-            maximal_untranslated_fraction: float = 1.0,
+            max_fails: float = 1.0,
             # Translation specification
             reverse: bool = False,
             fmt: FormatType | None = None,
@@ -373,7 +373,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             copy: Literal[True] = True,
             ignore_names: Names[NameType] | None = None,
             override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
-            maximal_untranslated_fraction: float = 1.0,
+            max_fails: float = 1.0,
             # Translation specification
             reverse: bool = False,
             fmt: FormatType | None = None,
@@ -388,7 +388,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             copy: Literal[True] = True,
             ignore_names: Names[NameType] | None = None,
             override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
-            maximal_untranslated_fraction: float = 1.0,
+            max_fails: float = 1.0,
             # Translation specification
             reverse: bool = False,
             fmt: FormatType | None = None,
@@ -403,7 +403,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             copy: Literal[True] = True,
             ignore_names: Names[NameType] | None = None,
             override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
-            maximal_untranslated_fraction: float = 1.0,
+            max_fails: float = 1.0,
             # Translation specification
             reverse: bool = False,
             fmt: FormatType | None = None,
@@ -418,7 +418,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             copy: Literal[True] = True,
             ignore_names: Names[NameType] | None = None,
             override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
-            maximal_untranslated_fraction: float = 1.0,
+            max_fails: float = 1.0,
             # Translation specification
             reverse: bool = False,
             fmt: FormatType | None = None,
@@ -433,7 +433,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             copy: Literal[True] = True,
             ignore_names: Names[NameType] | None = None,
             override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
-            maximal_untranslated_fraction: float = 1.0,
+            max_fails: float = 1.0,
             # Translation specification
             reverse: bool = False,
             fmt: FormatType | None = None,
@@ -448,7 +448,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             copy: Literal[True] = True,
             ignore_names: Names[NameType] | None = None,
             override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
-            maximal_untranslated_fraction: float = 1.0,
+            max_fails: float = 1.0,
             # Translation specification
             reverse: bool = False,
             fmt: FormatType | None = None,
@@ -463,7 +463,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             copy: Literal[True] = True,
             ignore_names: Names[NameType] | None = None,
             override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
-            maximal_untranslated_fraction: float = 1.0,
+            max_fails: float = 1.0,
             # Translation specification
             reverse: bool = False,
             fmt: FormatType | None = None,
@@ -478,7 +478,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             copy: Literal[True] = True,
             ignore_names: Names[NameType] | None = None,
             override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
-            maximal_untranslated_fraction: float = 1.0,
+            max_fails: float = 1.0,
             # Translation specification
             reverse: bool = False,
             fmt: FormatType | None = None,
@@ -493,7 +493,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             copy: Literal[True] = True,
             ignore_names: Names[NameType] | None = None,
             override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
-            maximal_untranslated_fraction: float = 1.0,
+            max_fails: float = 1.0,
             # Translation specification
             reverse: bool = False,
             fmt: FormatType | None = None,
@@ -508,7 +508,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             copy: Literal[True] = True,
             ignore_names: Names[NameType] | None = None,
             override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
-            maximal_untranslated_fraction: float = 1.0,
+            max_fails: float = 1.0,
             # Translation specification
             reverse: bool = False,
             fmt: FormatType | None = None,
@@ -523,7 +523,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             copy: Literal[True] = True,
             ignore_names: Names[NameType] | None = None,
             override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
-            maximal_untranslated_fraction: float = 1.0,
+            max_fails: float = 1.0,
             # Translation specification
             reverse: bool = False,
             fmt: FormatType | None = None,
@@ -541,7 +541,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
                 copy: Literal[True] = True,
                 ignore_names: Names[NameType] | None = None,
                 override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
-                maximal_untranslated_fraction: float = 1.0,
+                max_fails: float = 1.0,
                 # Translation specification
                 reverse: bool = False,
                 fmt: FormatType | None = None,
@@ -556,7 +556,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
                 copy: Literal[True] = True,
                 ignore_names: Names[NameType] | None = None,
                 override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
-                maximal_untranslated_fraction: float = 1.0,
+                max_fails: float = 1.0,
                 # Translation specification
                 reverse: bool = False,
                 fmt: FormatType | None = None,
@@ -571,7 +571,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
                 copy: Literal[True] = True,
                 ignore_names: Names[NameType] | None = None,
                 override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
-                maximal_untranslated_fraction: float = 1.0,
+                max_fails: float = 1.0,
                 # Translation specification
                 reverse: bool = False,
                 fmt: FormatType | None = None,
@@ -586,7 +586,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
                 copy: Literal[False],
                 ignore_names: Names[NameType] | None = None,
                 override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
-                maximal_untranslated_fraction: float = 1.0,
+                max_fails: float = 1.0,
                 # Translation specification
                 reverse: bool = False,
                 fmt: FormatType | None = None,
@@ -602,7 +602,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
                 copy: Literal[False],
                 ignore_names: Names[NameType] | None = None,
                 override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
-                maximal_untranslated_fraction: float = 1.0,
+                max_fails: float = 1.0,
                 # Translation specification
                 reverse: bool = False,
                 fmt: FormatType | None = None,
@@ -617,7 +617,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             ignore_names: Names[NameType] | None = None,
             copy: Literal[True] = True,
             override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
-            maximal_untranslated_fraction: float = 1.0,
+            max_fails: float = 1.0,
             reverse: Literal[True] = True,
             fmt: FormatType | None = None,
         ) -> Translatable[NameType, str]: ...
@@ -631,7 +631,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             ignore_names: Names[NameType] | None = None,
             copy: Literal[True] = True,
             override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
-            maximal_untranslated_fraction: float = 1.0,
+            max_fails: float = 1.0,
             reverse: Literal[True] = True,
             fmt: FormatType | None = None,
         ) -> Translatable[NameType, IdType]: ...
@@ -645,7 +645,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
         ignore_names: Names[NameType] | None = None,
         copy: bool = True,
         override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
-        maximal_untranslated_fraction: float = 1.0,
+        max_fails: float = 1.0,
         reverse: bool = False,
         fmt: FormatType | None = None,
     ) -> Translatable[NameType, str] | None:
@@ -670,7 +670,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             copy: If ``False``, translate in-place and return ``None``.
             override_function: A callable ``(name, sources, ids) -> Source | None``. See :meth:`.Mapper.apply`
                 for details.
-            maximal_untranslated_fraction: The maximum fraction of IDs for which translation may fail. 1=disabled.
+            max_fails: The maximum fraction of IDs for which translation may fail. 1=disabled.
             reverse: If ``True``, perform translations back to IDs. Offline mode only.
             fmt: A :class:`format string <.Format>` such as **'{id}:{name}'** use. Default is :attr:`.Translator.fmt`.
 
@@ -696,8 +696,8 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             MissingNamesError: If `names` are not given and cannot be derived from `translatable`.
             MappingError: If any required (explicitly given) names fail to map to a source.
             MappingError: If name-to-source mapping is ambiguous.
-            ValueError: If `maximal_untranslated_fraction` is not a valid fraction.
-            TooManyFailedTranslationsError: If translation fails for more than `maximal_untranslated_fraction` of IDs.
+            ValueError: If `max_fails` is not a valid fraction.
+            TooManyFailedTranslationsError: If translation fails for more than `max_fails` of IDs.
             ConnectionStatusError: If ``reverse=True`` while the :class:`.Translator` is online.
             UserMappingError: If `override_function` returns a source which is not known, and
                 ``self.mapper.unknown_user_override_action != 'ignore'``.
@@ -720,7 +720,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             ignore_names=ignore_names,
             override_function=override_function,
             copy=copy,
-            maximal_untranslated_fraction=maximal_untranslated_fraction,
+            max_fails=max_fails,
             reverse=reverse,
             enable_uuid_heuristics=self._enable_uuid_heuristics,
         )
@@ -975,7 +975,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
         *,
         ignore_names: Names[NameType] | None = None,
         override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
-        maximal_untranslated_fraction: float = 1.0,
+        max_fails: float = 1.0,
         fmt: FormatType | None = None,
         path: PathLikeType = None,
     ) -> Self:
@@ -991,7 +991,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             ignore_names: Names **not** to translate, or a predicate ``(NameType) -> bool``.
             override_function: A callable ``(name, sources, ids) -> Source | None``. See :meth:`.Mapper.apply`
                 for details.
-            maximal_untranslated_fraction: The maximum fraction of IDs for which translation may fail. 1=disabled.
+            max_fails: The maximum fraction of IDs for which translation may fail. 1=disabled.
             fmt: A :class:`format string <.Format>` such as **'{id}:{name}'** use. Default is :attr:`.Translator.fmt`.
             path: If given, serialize the :class:`.Translator` to disk after retrieving data.
 
@@ -1015,7 +1015,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             names,
             ignore_names=ignore_names,
             override_function=override_function,
-            maximal_untranslated_fraction=maximal_untranslated_fraction,
+            max_fails=max_fails,
             fmt=fmt,
         )
         self.fetcher.close()
@@ -1044,7 +1044,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
         *,
         ignore_names: Names[NameType] | None = None,
         override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
-        maximal_untranslated_fraction: float = 1.0,
+        max_fails: float = 1.0,
         fmt: FormatType | None = None,
     ) -> TranslationMap[NameType, SourceType, IdType]:
         """Fetch translations.
@@ -1060,7 +1060,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             ignore_names: Names **not** to translate, or a predicate ``(NameType) -> bool``.
             override_function: A callable ``(name, sources, ids) -> Source | None``. See :meth:`.Mapper.apply`
                 for details.
-            maximal_untranslated_fraction: The maximum fraction of IDs for which translation may fail. 1=disabled.
+            max_fails: The maximum fraction of IDs for which translation may fail. 1=disabled.
             fmt: A :class:`format string <.Format>` such as **'{id}:{name}'** use. Default is :attr:`.Translator.fmt`.
 
         Returns:
@@ -1117,7 +1117,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
             names,
             ignore_names=ignore_names,
             override_function=override_function,
-            maximal_untranslated_fraction=maximal_untranslated_fraction,
+            max_fails=max_fails,
             fmt=fmt,
         )
 
@@ -1128,7 +1128,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
         *,
         ignore_names: Names[NameType] | None = None,
         override_function: UserOverrideFunction[NameType, SourceType, None] | None = None,
-        maximal_untranslated_fraction: float = 1.0,
+        max_fails: float = 1.0,
         fmt: FormatType | None = None,
     ) -> TranslationMap[NameType, SourceType, IdType]:
         fmt = self._fmt if fmt is None else Format.parse(fmt)
@@ -1153,7 +1153,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
                 self._fmt,
                 names,
                 ignore_names=ignore_names,
-                maximal_untranslated_fraction=maximal_untranslated_fraction,
+                max_fails=max_fails,
                 enable_uuid_heuristics=self._enable_uuid_heuristics,
             )
             if not task.name_to_source:

--- a/src/id_translation/translator_typing.py
+++ b/src/id_translation/translator_typing.py
@@ -67,7 +67,7 @@ class TranslateParams(_t.TypedDict, _t.Generic[_tt.NameType, _tt.SourceType, _tt
 
     .. note::
 
-       Does not include `translatable` or `inplace`.
+       Does not include `translatable` or `copy`.
 
 
     **Motivation**
@@ -79,7 +79,7 @@ class TranslateParams(_t.TypedDict, _t.Generic[_tt.NameType, _tt.SourceType, _tt
 
        def func(**kwargs: Unpack[AllTranslateParams]):
           translatable = kwargs["translatable"]
-          if isinstance(translatable, list) and kwargs.get(inplace, False):
+          if isinstance(translatable, list) and kwargs.get(copy, True):
               raise CustomException("we don't do that here")
 
           else:
@@ -94,15 +94,15 @@ class TranslateParams(_t.TypedDict, _t.Generic[_tt.NameType, _tt.SourceType, _tt
 
        @overload
        def func(
-           translatable: list, inplace: Literal[True],
+           translatable: list, copy: Literal[False],
            **kwargs: Unpack[TranslateParams]
        ) -> Never: ...
 
-       def func(translatable, inplace, **kwargs: Unpack[TranslateParams]):
+       def func(translatable, copy, **kwargs: Unpack[TranslateParams]):
            "Implementation as above"
 
-    since ``func(translatable=[], inplace=True)`` does not behave like
-    ``Translator.translate([], inplace=True)`` would. Functions that transparently wrap
+    since ``func(translatable=[], copy=False)`` does not behave like
+    ``Translator.translate([], copy=False)`` would. Functions that transparently wrap
     :meth:`.Translator.translate` should probably use :py:func:`functools.wraps` instead.
     """
 
@@ -118,7 +118,7 @@ class AllTranslateParams(TranslateParams[_tt.NameType, _tt.SourceType, _tt.IdTyp
     """All arguments of :meth:`.Translator.translate`."""
 
     translatable: _t.Required[_tt.Translatable[_tt.NameType, _tt.IdType]]
-    inplace: bool
+    copy: bool
 
 
 class FetchParams(_t.TypedDict, _t.Generic[_tt.NameType, _tt.SourceType, _tt.IdType], total=False):

--- a/src/id_translation/translator_typing.py
+++ b/src/id_translation/translator_typing.py
@@ -109,7 +109,7 @@ class TranslateParams(_t.TypedDict, _t.Generic[_tt.NameType, _tt.SourceType, _tt
     names: _tt.NameTypes[_tt.NameType] | _tt.NameToSource[_tt.NameType, _tt.SourceType] | None
     ignore_names: _tt.Names[_tt.NameType] | None
     override_function: _UserOverrideFunction[_tt.NameType, _tt.SourceType, None] | None
-    maximal_untranslated_fraction: float
+    max_fails: float
     reverse: bool
     fmt: _ot.FormatType | None
 

--- a/src/id_translation/types.py
+++ b/src/id_translation/types.py
@@ -97,7 +97,7 @@ and will do its best to return a data structure of the same type (albeit with el
 
    Dict values are always copied for translation.
 
-   Setting ``inplace=True`` merely controls whether the original dict is modified.
+   Setting ``copy=False`` merely controls whether the original dict is modified.
 """
 
 

--- a/src/id_translation/utils/translation_helper.py
+++ b/src/id_translation/utils/translation_helper.py
@@ -291,7 +291,7 @@ class TranslationHelper(_t.Generic[_tt.NameType, _tt.SourceType, _tt.IdType]):
             return self._make(fmt=user_params)
 
         if isinstance(user_params, _t.get_args(MaximalUntranslatedFractionTypes)):
-            return self._make(maximal_untranslated_fraction=user_params)
+            return self._make(max_fails=user_params)
 
         if isinstance(user_params, dict):
             params = self._make(**user_params)
@@ -358,7 +358,7 @@ class TranslationHelper(_t.Generic[_tt.NameType, _tt.SourceType, _tt.IdType]):
 
         types = [
             (str, "fmt", "see :class:`.Format`"),
-            (float, "maximal_untranslated_fraction", "where 0=disable check, 1=no missing IDs allowed"),
+            (float, "max_fails", "where 0=disable check, 1=no missing IDs allowed"),
         ]
 
         type_parts = []

--- a/tests/dio/integration/test_dask.py
+++ b/tests/dio/integration/test_dask.py
@@ -62,4 +62,4 @@ def test_series(translator, df):
 def test_inplace(translator, df, series):
     translatable = df[df.columns[0]] if series else df
     with pytest.raises(NotInplaceTranslatableError):
-        translator.translate(translatable, inplace=True)
+        translator.translate(translatable, copy=False)

--- a/tests/dio/integration/test_polars.py
+++ b/tests/dio/integration/test_polars.py
@@ -43,11 +43,15 @@ def df(data: dict[str, dict[IdTypes, str]]) -> pl.DataFrame:
     )
 
 
-@pytest.mark.parametrize("inplace", [False, True])
-def test_dataframe(translator, df, inplace):
-    actual: None | pl.DataFrame = translator.translate(df, inplace=inplace)
-    assert (actual is None) == inplace
-    assert (df if inplace else actual).to_dict(as_series=False) == EXPECTED
+@pytest.mark.parametrize("copy", [True, False])
+def test_dataframe(translator, df, copy):
+    actual: None | pl.DataFrame = translator.translate(df, copy=copy)
+    if copy:
+        assert actual is not None
+        assert actual.to_dict(as_series=False) == EXPECTED
+    else:
+        assert actual is None
+        assert df.to_dict(as_series=False) == EXPECTED
 
 
 def test_series(translator, df):

--- a/tests/dvdrental/test_dvdrental.py
+++ b/tests/dvdrental/test_dvdrental.py
@@ -23,7 +23,7 @@ def test_dvd_rental(dialect, with_schema):
         Path(__file__).with_name("translated.csv"), index_col=0, parse_dates=["rental_date", "return_date"]
     )
     actual = get_df(dialect).loc[expected.index]
-    assert translator.translate(actual, inplace=True) is None
+    assert translator.translate(actual, copy=False) is None
     pd.testing.assert_frame_equal(actual, expected)
 
 

--- a/tests/dvdrental/test_key_events.py
+++ b/tests/dvdrental/test_key_events.py
@@ -87,7 +87,7 @@ def get_key_event_details(dialect, caplog):
 
     # Called for every function. Would be nice if this could be per parameter.
     translator: Translator[str, str, int] = Translator.from_config(*setup_for_dialect(dialect))
-    translator.translate(get_df(dialect), inplace=True)
+    translator.translate(get_df(dialect), copy=False)
 
     ret = []
     for i, r in enumerate(caplog.records):

--- a/tests/offline/test_translator_typing/test_typed_dicts.py
+++ b/tests/offline/test_translator_typing/test_typed_dicts.py
@@ -61,11 +61,11 @@ def test_fetch():
         assert translator.fetch(**kwargs).to_dicts() == EXPECTED_TRANSLATION_MAP_TO_DICTS
 
     with pytest.raises(TypeError):
-        call(inplace=False)  # type: ignore[call-arg]
+        call(copy=True)  # type: ignore[call-arg]
     with pytest.raises(TypeError):
         call(reverse=False)  # type: ignore[call-arg]
     with pytest.raises(TypeError):
-        call(inplace=True)  # type: ignore[call-arg]
+        call(copy=False)  # type: ignore[call-arg]
     with pytest.raises(TypeError):
         call(reverse=True)  # type: ignore[call-arg]
 
@@ -86,11 +86,11 @@ def test_go_offline():
         assert not translator.online
 
     with pytest.raises(TypeError):
-        call(inplace=False)  # type: ignore[call-arg]
+        call(copy=True)  # type: ignore[call-arg]
     with pytest.raises(TypeError):
         call(reverse=False)  # type: ignore[call-arg]
     with pytest.raises(TypeError):
-        call(inplace=True)  # type: ignore[call-arg]
+        call(copy=False)  # type: ignore[call-arg]
     with pytest.raises(TypeError):
         call(reverse=True)  # type: ignore[call-arg]
 
@@ -103,19 +103,19 @@ def test_translate():
     params = tt.TranslateParams[str, bool, int | UUID]()
     translatable = make_translatable()
 
-    actual = TypedTranslator().translate(translatable, inplace=False, **params)
+    actual = TypedTranslator().translate(translatable, copy=True, **params)
     assert actual == expected
     assert_type(actual, dict[str, list[str]])
 
     def call(t: UnionDict, **kwargs: Unpack[tt.TranslateParams[str, bool, int | UUID]]) -> None:
-        actual = TypedTranslator().translate(t, inplace=False, **kwargs)
+        actual = TypedTranslator().translate(t, copy=True, **kwargs)
         assert actual == expected
         assert_type(actual, dict[str, list[str]])
 
     with pytest.raises(TypeError):
-        call(translatable, inplace=False)  # type: ignore[call-arg]
+        call(translatable, copy=True)  # type: ignore[call-arg]
     with pytest.raises(TypeError):
-        call(translatable, inplace=True)  # type: ignore[call-arg]
+        call(translatable, copy=False)  # type: ignore[call-arg]
     with pytest.raises(TypeError):
         call(translatable, path="")  # type: ignore[call-arg]
 
@@ -147,7 +147,7 @@ def test_translate_full():
     with pytest.raises(TypeError):
         call(translatable=translatable, path="")  # type: ignore[call-arg]
 
-    call(translatable=translatable, inplace=False)
+    call(translatable=translatable, copy=True)
     call(translatable=translatable)
 
 
@@ -162,7 +162,7 @@ def test_copy():
     copy = translator.copy(**params)
 
     with pytest.raises(TypeError):
-        translator.copy(inplace=True)  # type: ignore[call-arg]
+        translator.copy(copy=False)  # type: ignore[call-arg]
 
     assert copy.enable_uuid_heuristics is True
     assert translator.enable_uuid_heuristics is False

--- a/tests/overload/test_dict.py
+++ b/tests/overload/test_dict.py
@@ -12,18 +12,18 @@ def type_dict_primitive() -> None:
 
     di = {1: 1}
     assert_type(t.translate(di), expected)
-    assert_type(t.translate(di, inplace=False), expected)
-    assert_type(t.translate(di, inplace=True), None)
+    assert_type(t.translate(di, copy=True), expected)
+    assert_type(t.translate(di, copy=False), None)
 
     ds = {1: "1"}
     assert_type(t.translate(ds), expected)
-    assert_type(t.translate(ds, inplace=False), expected)
-    assert_type(t.translate(ds, inplace=True), None)
+    assert_type(t.translate(ds, copy=True), expected)
+    assert_type(t.translate(ds, copy=False), None)
 
     du = {1: UUID(int=0)}
     assert_type(t.translate(du), expected)
-    assert_type(t.translate(du, inplace=False), expected)
-    assert_type(t.translate(du, inplace=True), None)
+    assert_type(t.translate(du, copy=True), expected)
+    assert_type(t.translate(du, copy=False), None)
 
 
 def type_dict_set() -> None:
@@ -31,13 +31,13 @@ def type_dict_set() -> None:
 
     dsi = {1: {1}}
     assert_type(t.translate(dsi), expected)
-    assert_type(t.translate(dsi, inplace=False), expected)
-    assert_type(t.translate(dsi, inplace=True), None)
+    assert_type(t.translate(dsi, copy=True), expected)
+    assert_type(t.translate(dsi, copy=False), None)
 
     dss = {1: {"1"}}
     assert_type(t.translate(dss), expected)
-    assert_type(t.translate(dss, inplace=False), expected)
-    assert_type(t.translate(dss, inplace=True), None)
+    assert_type(t.translate(dss, copy=True), expected)
+    assert_type(t.translate(dss, copy=False), None)
 
 
 def type_dict_list() -> None:
@@ -45,13 +45,13 @@ def type_dict_list() -> None:
 
     dli = {1: [1]}
     assert_type(t.translate(dli), expected)
-    assert_type(t.translate(dli, inplace=False), expected)
-    assert_type(t.translate(dli, inplace=True), None)
+    assert_type(t.translate(dli, copy=True), expected)
+    assert_type(t.translate(dli, copy=False), None)
 
     dss = {1: ["1"]}
     assert_type(t.translate(dss), expected)
-    assert_type(t.translate(dss, inplace=False), expected)
-    assert_type(t.translate(dss, inplace=True), None)
+    assert_type(t.translate(dss, copy=True), expected)
+    assert_type(t.translate(dss, copy=False), None)
 
 
 def type_dict_one_tuple() -> None:
@@ -59,13 +59,13 @@ def type_dict_one_tuple() -> None:
 
     dti = {1: (1,)}  # Anonymous instance is cast to vararg-tuple by mypy
     assert_type(t.translate(dti), expected)
-    assert_type(t.translate(dti, inplace=False), expected)
-    assert_type(t.translate(dti, inplace=True), None)
+    assert_type(t.translate(dti, copy=True), expected)
+    assert_type(t.translate(dti, copy=False), None)
 
     dts = {1: ("1",)}  # Anonymous instance is cast to vararg-tuple by mypy
     assert_type(t.translate(dts), expected)
-    assert_type(t.translate(dts, inplace=False), expected)
-    assert_type(t.translate(dts, inplace=True), None)
+    assert_type(t.translate(dts, copy=True), expected)
+    assert_type(t.translate(dts, copy=False), None)
 
 
 def type_dict_two_tuple() -> None:
@@ -73,13 +73,13 @@ def type_dict_two_tuple() -> None:
 
     di = {1: (1, 2)}  # Anonymous instance is cast to vararg-tuple by mypy
     assert_type(t.translate(di), expected)
-    assert_type(t.translate(di, inplace=False), expected)
-    assert_type(t.translate(di, inplace=True), None)
+    assert_type(t.translate(di, copy=True), expected)
+    assert_type(t.translate(di, copy=False), None)
 
     ds = {1: ("1", "2")}  # Anonymous instance is cast to vararg-tuple by mypy
     assert_type(t.translate(ds), expected)
-    assert_type(t.translate(ds, inplace=False), expected)
-    assert_type(t.translate(ds, inplace=True), None)
+    assert_type(t.translate(ds, copy=True), expected)
+    assert_type(t.translate(ds, copy=False), None)
 
 
 def type_dict_three_tuple() -> None:
@@ -87,13 +87,13 @@ def type_dict_three_tuple() -> None:
 
     dti = {1: (1, 2, 3)}  # Anonymous instance is cast to vararg-tuple by mypy
     assert_type(t.translate(dti), expected)
-    assert_type(t.translate(dti, inplace=False), expected)
-    assert_type(t.translate(dti, inplace=True), None)
+    assert_type(t.translate(dti, copy=True), expected)
+    assert_type(t.translate(dti, copy=False), None)
 
     dts = {1: ("1", "2", "3")}  # Anonymous instance is cast to vararg-tuple by mypy
     assert_type(t.translate(dts), expected)
-    assert_type(t.translate(dts, inplace=False), expected)
-    assert_type(t.translate(dts, inplace=True), None)
+    assert_type(t.translate(dts, copy=True), expected)
+    assert_type(t.translate(dts, copy=False), None)
 
 
 def type_dict_var_tuple() -> None:
@@ -101,10 +101,10 @@ def type_dict_var_tuple() -> None:
 
     dti = {1: tuple(range(1))}
     assert_type(t.translate(dti), expected)
-    assert_type(t.translate(dti, inplace=False), expected)
-    assert_type(t.translate(dti, inplace=True), None)
+    assert_type(t.translate(dti, copy=True), expected)
+    assert_type(t.translate(dti, copy=False), None)
 
     dts = {1: tuple("1")}
     assert_type(t.translate(dts), expected)
-    assert_type(t.translate(dts, inplace=False), expected)
-    assert_type(t.translate(dts, inplace=True), None)
+    assert_type(t.translate(dts, copy=True), expected)
+    assert_type(t.translate(dts, copy=False), None)

--- a/tests/overload/test_misc.py
+++ b/tests/overload/test_misc.py
@@ -11,13 +11,13 @@ def type_list() -> None:
 
     li = [1]
     assert_type(t.translate(li), expected)
-    assert_type(t.translate(li, inplace=False), expected)
-    assert_type(t.translate(li, inplace=True), None)
+    assert_type(t.translate(li, copy=True), expected)
+    assert_type(t.translate(li, copy=False), None)
 
     ls = ["1"]
     assert_type(t.translate(ls), expected)
-    assert_type(t.translate(ls, inplace=False), expected)
-    assert_type(t.translate(ls, inplace=True), None)
+    assert_type(t.translate(ls, copy=True), expected)
+    assert_type(t.translate(ls, copy=False), None)
 
 
 # This doesn't seem to work; nested generic type issue?
@@ -27,13 +27,13 @@ def type_list() -> None:
 #
 #     lli = [[1]]
 #     assert_type(t.translate(lli), expected)
-#     assert_type(t.translate(lli, inplace=False), expected)
-#     assert_type(t.translate(lli, inplace=True), None)
+#     assert_type(t.translate(lli, copy=True), expected)
+#     assert_type(t.translate(lli, copy=False), None)
 #
 #     lls = ["1"]
 #     assert_type(t.translate(lls), expected)
-#     assert_type(t.translate(lls, inplace=False), expected)
-#     assert_type(t.translate(lls, inplace=True), None)
+#     assert_type(t.translate(lls, copy=True), expected)
+#     assert_type(t.translate(lls, copy=False), None)
 
 
 def type_set() -> None:
@@ -41,10 +41,10 @@ def type_set() -> None:
 
     si = {1}
     assert_type(t.translate(si), expected)
-    assert_type(t.translate(si, inplace=False), expected)
-    assert_type(t.translate(si, inplace=True), None)
+    assert_type(t.translate(si, copy=True), expected)
+    assert_type(t.translate(si, copy=False), None)
 
     ss = {"1"}
     assert_type(t.translate(ss), expected)
-    assert_type(t.translate(ss, inplace=False), expected)
-    assert_type(t.translate(ss, inplace=True), None)
+    assert_type(t.translate(ss, copy=True), expected)
+    assert_type(t.translate(ss, copy=False), None)

--- a/tests/overload/test_pandas.py
+++ b/tests/overload/test_pandas.py
@@ -13,25 +13,25 @@ def type_frame() -> None:
     df = pd.DataFrame()
 
     assert_type(t.translate(df), "pd.DataFrame")
-    assert_type(t.translate(df, inplace=False), "pd.DataFrame")
+    assert_type(t.translate(df, copy=True), "pd.DataFrame")
 
     if ID_TRANSLATION_PANDAS_IS_TYPED:
-        assert_type(t.translate(df, inplace=True), None)
+        assert_type(t.translate(df, copy=False), None)
 
 
 def type_series() -> None:
     series = pd.Series([1])
 
     assert_type(t.translate(series), "pd.Series[OutType]")
-    assert_type(t.translate(series, inplace=False), "pd.Series[OutType]")
+    assert_type(t.translate(series, copy=True), "pd.Series[OutType]")
     if ID_TRANSLATION_PANDAS_IS_TYPED:
-        assert_type(t.translate(series, inplace=True), None)
+        assert_type(t.translate(series, copy=False), None)
 
 
 def type_index() -> None:
     index = pd.Index([1])
 
     assert_type(t.translate(index), "pd.Index[OutType]")
-    assert_type(t.translate(index, inplace=False), "pd.Index[OutType]")
+    assert_type(t.translate(index, copy=True), "pd.Index[OutType]")
     if ID_TRANSLATION_PANDAS_IS_TYPED:
-        assert_type(t.translate(index, inplace=True), NoReturn)
+        assert_type(t.translate(index, copy=False), NoReturn)

--- a/tests/overload/test_primitive.py
+++ b/tests/overload/test_primitive.py
@@ -11,19 +11,19 @@ OutType = str
 def type_int():
     i: int = 1
     assert_type(t.translate(i), OutType)
-    assert_type(t.translate(i, inplace=False), OutType)
-    assert_type(t.translate(i, inplace=True), NoReturn)
+    assert_type(t.translate(i, copy=True), OutType)
+    assert_type(t.translate(i, copy=False), NoReturn)
 
 
 def type_str():
     s = "1"
     assert_type(t.translate(s), OutType)
-    assert_type(t.translate(s, inplace=False), OutType)
-    assert_type(t.translate(s, inplace=True), NoReturn)
+    assert_type(t.translate(s, copy=True), OutType)
+    assert_type(t.translate(s, copy=False), NoReturn)
 
 
 def type_uuid():
     u = UUID(int=0)
     assert_type(t.translate(u), OutType)
-    assert_type(t.translate(u, inplace=False), OutType)
-    assert_type(t.translate(u, inplace=True), NoReturn)
+    assert_type(t.translate(u, copy=True), OutType)
+    assert_type(t.translate(u, copy=False), NoReturn)

--- a/tests/overload/test_tuple.py
+++ b/tests/overload/test_tuple.py
@@ -11,13 +11,13 @@ def type_one_tuple() -> None:
 
     ti = (1,)
     assert_type(t.translate(ti), expected)
-    assert_type(t.translate(ti, inplace=False), expected)
-    assert_type(t.translate(ti, inplace=True), NoReturn)
+    assert_type(t.translate(ti, copy=True), expected)
+    assert_type(t.translate(ti, copy=False), NoReturn)
 
     ts = ("1",)
     assert_type(t.translate(ts), expected)
-    assert_type(t.translate(ts, inplace=False), expected)
-    assert_type(t.translate(ts, inplace=True), NoReturn)
+    assert_type(t.translate(ts, copy=True), expected)
+    assert_type(t.translate(ts, copy=False), NoReturn)
 
 
 def type_two_tuple() -> None:
@@ -25,13 +25,13 @@ def type_two_tuple() -> None:
 
     ti = (1, 2)
     assert_type(t.translate(ti), expected)
-    assert_type(t.translate(ti, inplace=False), expected)
-    assert_type(t.translate(ti, inplace=True), NoReturn)
+    assert_type(t.translate(ti, copy=True), expected)
+    assert_type(t.translate(ti, copy=False), NoReturn)
 
     ts = ("1", "2")
     assert_type(t.translate(ts), expected)
-    assert_type(t.translate(ts, inplace=False), expected)
-    assert_type(t.translate(ts, inplace=True), NoReturn)
+    assert_type(t.translate(ts, copy=True), expected)
+    assert_type(t.translate(ts, copy=False), NoReturn)
 
 
 def type_three_tuple() -> None:
@@ -39,10 +39,10 @@ def type_three_tuple() -> None:
 
     ti = (1, 2, 3)
     assert_type(t.translate(ti), expected)
-    assert_type(t.translate(ti, inplace=False), expected)
-    assert_type(t.translate(ti, inplace=True), NoReturn)
+    assert_type(t.translate(ti, copy=True), expected)
+    assert_type(t.translate(ti, copy=False), NoReturn)
 
     ts = ("1", "2", "3")
     assert_type(t.translate(ts), expected)
-    assert_type(t.translate(ts, inplace=False), expected)
-    assert_type(t.translate(ts, inplace=True), NoReturn)
+    assert_type(t.translate(ts, copy=True), expected)
+    assert_type(t.translate(ts, copy=False), NoReturn)

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -44,3 +44,36 @@ class TestInplace:
     def test_new_and_old(self):
         with pytest.raises(TypeError, match="both `inplace` and `copy`"):
             Translator().translate([1], inplace=False, copy=True, names="name")  # type: ignore[call-overload]
+
+
+class TestMaximalUntranslatedFraction:
+    MESSAGE = (
+        r"Translator.translate(): The `maximal_untranslated_fraction` parameter is deprecated; use `max_fails` instead."
+    )
+    MATCH = re.escape(MESSAGE)
+
+    def test(self, monkeypatch):
+        monkeypatch.setattr(_compat, "WARNED", set())
+
+        translatable = [1]
+
+        with pytest.warns(DeprecationWarning, match=self.MATCH):
+            actual = Translator().translate(translatable, maximal_untranslated_fraction=0, names="name")  # type: ignore[call-overload]
+
+        assert actual is not None
+        assert actual == ["1:name-of-1"]
+        assert translatable == [1]
+
+    def test_emit_only_once(self, monkeypatch):
+        monkeypatch.setattr(_compat, "WARNED", set())
+
+        with pytest.warns() as w:
+            Translator().translate([1], maximal_untranslated_fraction=0, names="name")  # type: ignore[call-overload]
+            Translator().translate([1], maximal_untranslated_fraction=0, names="name")  # type: ignore[call-overload]
+
+        n_matches = sum(self.MESSAGE in str(wm.message) for wm in w.list)
+        assert n_matches == 1
+
+    def test_new_and_old(self):
+        with pytest.raises(TypeError, match="both `maximal_untranslated_fraction` and `max_fails`"):
+            Translator().translate([1], maximal_untranslated_fraction=0, max_fails=0, names="name")  # type: ignore[call-overload]

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -1,0 +1,46 @@
+import re
+
+import pytest
+from id_translation import Translator, _compat
+
+
+class TestInplace:
+    MESSAGE = r"Translator.translate(): The `inplace` parameter is deprecated; use `copy` instead."
+    MATCH = re.escape(MESSAGE)
+
+    def test_true(self, monkeypatch):
+        monkeypatch.setattr(_compat, "WARNED", set())
+
+        translatable = [1]
+
+        with pytest.warns(DeprecationWarning, match=self.MATCH):
+            actual = Translator().translate(translatable, inplace=True, names="name")  # type: ignore[call-overload]
+
+        assert actual is None
+        assert translatable == ["1:name-of-1"]
+
+    def test_false(self, monkeypatch):
+        monkeypatch.setattr(_compat, "WARNED", set())
+
+        translatable = [1]
+
+        with pytest.warns(DeprecationWarning, match=self.MATCH):
+            actual = Translator().translate(translatable, inplace=False, names="name")  # type: ignore[call-overload]
+
+        assert actual is not None
+        assert actual == ["1:name-of-1"]
+        assert translatable == [1]
+
+    def test_emit_only_once(self, monkeypatch):
+        monkeypatch.setattr(_compat, "WARNED", set())
+
+        with pytest.warns() as w:
+            Translator().translate([1], inplace=False, names="name")  # type: ignore[call-overload]
+            Translator().translate([1], inplace=False, names="name")  # type: ignore[call-overload]
+
+        n_matches = sum(self.MESSAGE in str(wm.message) for wm in w.list)
+        assert n_matches == 1
+
+    def test_new_and_old(self):
+        with pytest.raises(TypeError, match="both `inplace` and `copy`"):
+            Translator().translate([1], inplace=False, copy=True, names="name")  # type: ignore[call-overload]

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -135,7 +135,7 @@ def _translate(translator):
     [
         (object(), UntranslatableTypeError, {"names": 1}),
         ((1, 2), MissingNamesError, {}),
-        ((1, 2), NotInplaceTranslatableError, {"inplace": True, "names": "positive_numbers"}),
+        ((1, 2), NotInplaceTranslatableError, {"copy": False, "names": "positive_numbers"}),
     ],
 )
 def test_bad_translatable(translator, data, clazz, kwargs):
@@ -370,7 +370,7 @@ def test_untranslated_reporting(caplog):
     translator.translate(
         {"none": [-1, -100], "partial": [-1, 1, 2], "all": [0, 1]},
         override_function=lambda *_: "source",
-        inplace=True,
+        copy=False,
     )
 
     for r in caplog.records:
@@ -392,7 +392,7 @@ def test_reverse(hex_fetcher):
 
     translated = {"positive_numbers": ["<Failed: id=-1>", "0:0x0, positive=True", "1:0x1, positive=True"]}
     assert_type(translated, dict[str, list[str]])
-    assert translated == translator.translate({"positive_numbers": [-1, 0, 1]}, inplace=False)
+    assert translated == translator.translate({"positive_numbers": [-1, 0, 1]}, copy=True)
 
     actual = translator.translate(translated, reverse=True)
     assert_type(actual, dict[str, list[int]])  # type: ignore[assert-type]  # Overloads are incomplete for reverse=True

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -348,13 +348,13 @@ def test_no_names(translator):
 def test_untranslated_fraction_single_name():
     translator = UnitTestTranslator({"source": {"id": [0], "name": ["zero"]}}, default_fmt="{id} not translated")
 
-    translator.translate([0, 1], names="source", maximal_untranslated_fraction=0.5)
+    translator.translate([0, 1], names="source", max_fails=0.5)
 
     with pytest.raises(TooManyFailedTranslationsError, match="translate 1/3"):
-        translator.translate([0, 0, 1], names="source", maximal_untranslated_fraction=0.0)
+        translator.translate([0, 0, 1], names="source", max_fails=0.0)
 
     with pytest.raises(TooManyFailedTranslationsError, match="translate 1/1"):
-        translator.translate(1, names="source", maximal_untranslated_fraction=0.0)
+        translator.translate(1, names="source", max_fails=0.0)
 
 
 def test_untranslated_fraction_multiple_names(translator, hex_fetcher):
@@ -362,7 +362,7 @@ def test_untranslated_fraction_multiple_names(translator, hex_fetcher):
     translatable = {"negative_numbers": [1, 1], "positive_numbers": [0, 1, 2]}
 
     with pytest.raises(TooManyFailedTranslationsError, match="translate 2/2"):
-        translator.translate(translatable, maximal_untranslated_fraction=0.0)
+        translator.translate(translatable, max_fails=0.0)
 
 
 def test_untranslated_reporting(caplog):
@@ -399,7 +399,7 @@ def test_reverse(hex_fetcher):
     assert actual == {"positive_numbers": ["<Failed: id='<Failed: id=-1>'>", 0, 1]}, "Original format"
 
     with pytest.raises(TooManyFailedTranslationsError, match=r"Sample IDs: \['<Failed: id=-1>'\]"):
-        translator.translate(translated, reverse=True, maximal_untranslated_fraction=0)
+        translator.translate(translated, reverse=True, max_fails=0)
 
 
 def test_reverse_primitive(hex_fetcher):
@@ -644,7 +644,7 @@ def test_fetch(translator):
 
 def test_fetch_args(translator):
     with pytest.raises(TooManyFailedTranslationsError):
-        translator.fetch({"positive_numbers": [-1]}, maximal_untranslated_fraction=0)
+        translator.fetch({"positive_numbers": [-1]}, max_fails=0)
 
     assert translator.fetch({"positive_numbers": [-1]}).to_dicts() == {
         "positive_numbers": {"hex": [], "id": [], "positive": []}
@@ -663,10 +663,10 @@ def test_go_offline_args(translator):
     assert id(translator.fetch) != original_fetcher_id
 
     with pytest.raises(TooManyFailedTranslationsError):
-        translator.go_offline({"positive_numbers": [-1]}, maximal_untranslated_fraction=0)
+        translator.go_offline({"positive_numbers": [-1]}, max_fails=0)
     assert translator.online
 
-    translator.go_offline({"positive_numbers": [1]}, maximal_untranslated_fraction=0)
+    translator.go_offline({"positive_numbers": [1]}, max_fails=0)
     assert not translator.online
     assert translator.cache.to_dicts() == {"positive_numbers": {"hex": ["0x1"], "id": [1], "positive": [True]}}
 
@@ -692,7 +692,7 @@ def test_fetcher_clone_type_error():
 
 
 def test_empty(translator):
-    actual = translator.translate({"p": [], "n": [-1]}, maximal_untranslated_fraction=1.0)
+    actual = translator.translate({"p": [], "n": [-1]}, max_fails=1.0)
     assert actual == {"p": [], "n": ["-1:-0x1, positive=False"]}
     assert translator.translated_names(with_source=True) == {"n": "negative_numbers", "p": "positive_numbers"}
 

--- a/tests/transform/test_factory.py
+++ b/tests/transform/test_factory.py
@@ -12,7 +12,7 @@ def test_factory():
     translator = Translator[str, str, int].from_config(ROOT / "main.toml", extra_fetchers=[ROOT / "fetcher-only.toml"])
 
     actual = {"guests": [1991, 1999, 2021], "drinking_preferences_bitmask": [2, 3, 0]}
-    translator.translate(actual, inplace=True)
+    translator.translate(actual, copy=False)
 
     assert actual == {
         "guests": ["Oh, it's you again Richard.", "Oh, it's you again Sofia.", "What's up, Morris?"],

--- a/tests/utils/test_helper/test_convert.py
+++ b/tests/utils/test_helper/test_convert.py
@@ -19,8 +19,8 @@ def test_str():
 
 
 @pytest.mark.parametrize("value", [0.0, 0])
-def test_maximal_untranslated_fraction(value):
-    assert helper.convert_user_params(value) == {"maximal_untranslated_fraction": 0.0}
+def test_max_fails(value):
+    assert helper.convert_user_params(value) == {"max_fails": 0.0}
 
 
 def test_unknown():

--- a/tests/utils/test_helper/test_copy.py
+++ b/tests/utils/test_helper/test_copy.py
@@ -5,7 +5,7 @@ pytestmark = pytest.mark.xfail(strict=True, reason="Not implemented.")
 
 
 def _test_no_untranslated(get_3_imdb):
-    kwargs = {"maximal_untranslated_fraction": 0, "default_fmt_placeholders": None}
+    kwargs = {"max_fails": 0, "default_fmt_placeholders": None}
     with pytest.raises(TooManyFailedTranslationsError):
         get_3_imdb(translate=kwargs)
 

--- a/tests/utils/test_helper/test_docs.py
+++ b/tests/utils/test_helper/test_docs.py
@@ -7,7 +7,7 @@ from id_translation.utils.translation_helper import TranslationHelper
 def test_default():
     param = TranslationHelper(Translator).make_user_params_docstring()
     assert "'fmt'" in param
-    assert "'maximal_untranslated_fraction'" in param
+    assert "'max_fails'" in param
 
 
 def test_fixed_fmt():
@@ -15,8 +15,8 @@ def test_fixed_fmt():
 
     param = helper.make_user_params_docstring()
     assert "'fmt'" not in param
-    assert "'maximal_untranslated_fraction'" in param
+    assert "'max_fails'" in param
 
     error = helper.make_type_error_docstring()
     assert "'fmt'" in error
-    assert "'maximal_untranslated_fraction'" not in error
+    assert "'max_fails'" not in error

--- a/tests/utils/test_helper/test_helper_reserved.py
+++ b/tests/utils/test_helper/test_helper_reserved.py
@@ -17,9 +17,9 @@ def test_fixed_translatable():
 
 
 def test_fixed_inplace():
-    match = r"Found protected keys={'inplace'} in fixed_params={'inplace': None}."
+    match = r"Found protected keys={'copy'} in fixed_params={'copy': None}."
     with pytest.raises(TypeError, match=match):
-        Helper(Translator, inplace=None)  # type: ignore[call-arg]
+        Helper(Translator, copy=None)  # type: ignore[call-arg]
 
 
 def test_all():

--- a/tests/utils/test_helper/test_hierarchy.py
+++ b/tests/utils/test_helper/test_hierarchy.py
@@ -6,19 +6,19 @@ helper = TranslationHelper[str, str, int](Translator(), user_params_name="hierar
 
 
 def test_user_overrides_default():
-    assert helper.apply(1, inplace=False, user_params="{title}", fmt="{name}") == "title-of-1"
-    assert helper.apply(1, inplace=False, user_params="{name}", fmt="{title}") == "name-of-1"
-    assert helper.apply(1, inplace=False, user_params=True) == "1:name-of-1"
-    assert helper.apply(1, inplace=False, user_params={}) == "1:name-of-1"
+    assert helper.apply(1, copy=True, user_params="{title}", fmt="{name}") == "title-of-1"
+    assert helper.apply(1, copy=True, user_params="{name}", fmt="{title}") == "name-of-1"
+    assert helper.apply(1, copy=True, user_params=True) == "1:name-of-1"
+    assert helper.apply(1, copy=True, user_params={}) == "1:name-of-1"
 
 
 def test_fixed_overrides_user():
     match = r"Found protected keys={'names'} in hierarchy={'names': None, 'fmt': ''}."
     with pytest.raises(TypeError, match=match):
-        helper.apply(1, inplace=False, user_params={"names": None, "fmt": ""})
+        helper.apply(1, copy=True, user_params={"names": None, "fmt": ""})
 
 
 def test_fixed_overrides_default():
     match = r"Found protected keys={'names'} in default_params={'names': None}."
     with pytest.raises(TypeError, match=match):
-        helper.apply(1, inplace=False, user_params=True, names=None)
+        helper.apply(1, copy=True, user_params=True, names=None)

--- a/tests/utils/test_helper/test_misc.py
+++ b/tests/utils/test_helper/test_misc.py
@@ -12,7 +12,7 @@ def test_translated_names():
     with pytest.raises(ValueError, match="TranslationHelper"):
         helper.name_to_source()
 
-    helper.apply(1, inplace=False, user_params=True)
+    helper.apply(1, copy=True, user_params=True)
     name_to_source = helper.name_to_source()
     assert name_to_source == {"h": "h"}
     assert translator.translated_names(True) == {"h": "h"}

--- a/tests/utils/test_helper/test_typing.py
+++ b/tests/utils/test_helper/test_typing.py
@@ -8,26 +8,26 @@ helper = TranslationHelper[str, str, int](Translator(), names="source")
 
 class TestTrue:
     def test_inplace_true(self):
-        result = helper.apply([1], inplace=True, user_params=True)
+        result = helper.apply([1], copy=False, user_params=True)
         assert_type(result, None)
 
     def test_inplace_false_anonymous(self):
-        result = helper.apply([1], inplace=False, user_params=True)
+        result = helper.apply([1], copy=True, user_params=True)
         assert_type(result, list[str])  # type: ignore[assert-type]  # this is what we actually want
         assert_type(result, Any)  # this is what we know we get
 
     def test_inplace_false_reassigned(self):
         result = [1]
-        result = helper.apply(result, inplace=False, user_params=True)
+        result = helper.apply(result, copy=True, user_params=True)
         assert_type(result, list[str])  # type: ignore[assert-type]  # this is what we actually want
         assert_type(result, list[int])  # this is what we know we get - WRONG
 
 
 class TestFalse:
     def test_inplace_true(self):
-        result = helper.apply([1], inplace=True, user_params=False)
+        result = helper.apply([1], copy=False, user_params=False)
         assert_type(result, None)
 
     def test_inplace_false(self):
-        result = helper.apply([1], inplace=False, user_params=False)
+        result = helper.apply([1], copy=True, user_params=False)
         assert_type(result, list[int])


### PR DESCRIPTION
## Rename `inplace` -> `copy`
Fixes #248 

## Rename `maximal_untranslated_fraction` -> `max_fails`
Fixes #230