### PR TITLE
Update Transformers API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - The docs no longer incorrectly state the `max_fails` stops working when `default_fmt_placeholders` are in use.
 - Fix `max_fails` check when transformers are in use.
+- The `BitmaskTransformer` no longer uses missing IDs in decomposed bitmask translations.
 
 ## [0.13.0] - 2025-04-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- The docs no longer incorrectly state the `max_fails` stops working when `default_fmt_placeholders` are in use.
+
 ## [0.13.0] - 2025-04-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Methods `MagicDict.real_get` and `real_contains`.
 
+### Changed
+- Make `Transformer` method parameters `positional`-only.
+
 ### Fixed
 - The docs no longer incorrectly state the `max_fails` stops working when `default_fmt_placeholders` are in use.
 - Fix `max_fails` check when transformers are in use.
 - The `BitmaskTransformer` no longer uses missing IDs in decomposed bitmask translations.
+
+### Removed
+- The `TransformerStop` class and associated functionality (it wasn't very useful).
 
 ## [0.13.0] - 2025-04-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Methods `MagicDict.real_get` and `real_contains`.
+
 ### Fixed
 - The docs no longer incorrectly state the `max_fails` stops working when `default_fmt_placeholders` are in use.
+- Fix `max_fails` check when transformers are in use.
 
 ## [0.13.0] - 2025-04-05
 

--- a/docs/documentation/translator-config.rst
+++ b/docs/documentation/translator-config.rst
@@ -76,11 +76,6 @@ Section: Unknown IDs
   in a ``[unknown_ids.overrides]``-subsection. See: :ref:`Subsection: Overrides` for details (context =
   :attr:`source <id_translation.types.SourceType>`).
 
-.. note::
-
-   Sources that are translated using default placeholders count as successful translations when using
-   :meth:`Translator.translate(max_fails != 1) <.Translator.translate>`.
-
 .. _translator-config-transform:
 
 Section: Transformations

--- a/src/id_translation/_tasks/_translate.py
+++ b/src/id_translation/_tasks/_translate.py
@@ -222,11 +222,14 @@ class TranslationTask(MappingTask[NameType, SourceType, IdType]):
 
         for name, ids in name_to_ids.items():
             source = tmap.name_to_source[name]
-            known = translations[source].real
-            if self.reverse != tmap.reverse_mode:
-                known = set(known.values())  # type: ignore[assignment]
+            magic_dict = translations[source]
 
-            is_missing = [idx not in known for idx in ids]
+            if self.reverse == tmap.reverse_mode:
+                is_known = magic_dict.real_contains
+            else:
+                is_known = {*magic_dict.real.values()}.__contains__
+
+            is_missing = [not is_known(idx) for idx in ids]
             n_untranslated = sum(is_missing)
             if n_untranslated == 0:
                 continue

--- a/src/id_translation/_translator.py
+++ b/src/id_translation/_translator.py
@@ -84,8 +84,7 @@ class Translator(Generic[NameType, SourceType, IdType], HasSources[SourceType]):
         mapper: A :class:`~.mapping.Mapper` instance for binding names to sources.
         default_fmt: Alternative :class:`.Format` to use fallback translation of unknown IDs.
         default_fmt_placeholders: Shared and/or source-specific default placeholder values for unknown IDs. See
-            :meth:`InheritedKeysDict.make() <rics.collections.dicts.InheritedKeysDict.make>` for details. IDs translated
-            using defaults count as successful when using :meth:`Translator.translate(max_fails \< 1) <translate>`.
+            :meth:`InheritedKeysDict.make() <rics.collections.dicts.InheritedKeysDict.make>` for details.
         enable_uuid_heuristics: Improves matching when :py:class:`~uuid.UUID`-like IDs are in use.
         transformers: A dict ``{source: transformer}`` of initialized :class:`.Transformer` instances.
 

--- a/src/id_translation/offline/_magic_dict.py
+++ b/src/id_translation/offline/_magic_dict.py
@@ -21,13 +21,9 @@ class MagicDict(MutableMapping[IdType, str]):
     Args:
         real_translations: A dict holding :attr:`real` translations.
         default_value: A string with exactly one or zero placeholders.
-        enable_uuid_heuristics: Improves matching when :py:class:`~uuid.UUID`-like IDs are in use.
+        enable_uuid_heuristics: Improves matching when :py:class:`~uuid.UUID`-like IDs are in use. Forcibly set to
+            ``False`` if any of the `real_translations` are not ``UUID``-like.
         transformer: Initialized :class:`.Transformer` instance.
-
-            .. note:
-
-               If any of the `real_translations` are not ``UUID``-like,
-               ``enable_uuid_heuristics`` is forcibly set to ``False``.
 
     Examples:
         **Similarities with the built-in dict**
@@ -109,12 +105,33 @@ class MagicDict(MutableMapping[IdType, str]):
             transformer.update_translations(real_translations)
             self._try_add_missing_key = transformer.try_add_missing_key
 
-    def get(self, __key: IdType, /, _: Any = None) -> str:
+    def get(self, key: IdType, /, _: Any = None) -> str:
         """Same as ``__getitem__``.
 
         Values for missing keys are generated from :attr:`default_value`.
         """
-        return self[__key]
+        return self[key]
+
+    def real_get(self, key: IdType) -> str | None:
+        """Attempt to get an actual translation.
+
+        This method behaves like ``MagicDict.__getitem__``, applying all appropriate heuristics **except** for falling
+        back to the :attr:`default_value`. Returns ``None`` if the `key` cannot be mapped to a real values, like the
+        regular ``dict.get`` method would.
+
+        To bypass the heuristics, use :attr:`real` and :meth:`dict.get` instead. Note that the backing dict may still
+        contain mappings added transformers, since the :meth:`.Transformer.update_translations` interface is called
+        during initialization.
+        """
+        if key in self._real:
+            return self._real[key]
+
+        key = self._on_read(key)
+        return self._real.get(key)
+
+    def real_contains(self, key: IdType, /) -> bool:
+        """Check if an actual translation exists using :meth:`real_get`."""
+        return self.real_get(key) is not None
 
     @property
     def real(self) -> dict[IdType, str]:
@@ -130,11 +147,8 @@ class MagicDict(MutableMapping[IdType, str]):
         return _uuid_utils.try_cast_one(key) if self._cast_key else key
 
     def __getitem__(self, key: IdType) -> str:
-        if key in self._real:
-            return self._real[key]
-
-        key = self._on_read(key)
-        return self._real[key] if key in self._real else self.default_value.format(key)
+        value = self.real_get(key)
+        return self.default_value.format(key) if value is None else value
 
     def __contains__(self, key: Any) -> bool:
         """Always returns ``True``."""

--- a/src/id_translation/transform/_impl/bitmask.py
+++ b/src/id_translation/transform/_impl/bitmask.py
@@ -91,14 +91,14 @@ class BitmaskTransformer(Transformer[IdType]):
         self._force_real_translations = force_real_translations
 
     @classmethod
-    def update_ids(cls, ids: set[IdType]) -> None:
+    def update_ids(cls, ids: set[IdType], /) -> None:
         """Add decomposed bitmask values."""
         new_ids = set()
         for decomposed in map(cls.decompose_bitmask, ids):
             new_ids.update(decomposed)
         ids.update(new_ids)
 
-    def update_translations(self, translations: dict[IdType, str]) -> None:
+    def update_translations(self, translations: dict[IdType, str], /) -> None:
         """Join decomposed bitmask values using the `joiner` string."""
         ids_to_update: Iterable[IdType] = filter(self.is_decomposable, translations)
         if not self._force:

--- a/src/id_translation/transform/types.py
+++ b/src/id_translation/transform/types.py
@@ -11,12 +11,9 @@ class Transformer(_t.Protocol[_IdType]):
     """Transformation API type.
 
     Transformers are persistent entities owned by a single :class:`.Translator` instance.
-
-    Implementing :attr:`try_add_missing_key` is optional. Raise :class:`TransformerStop` to prevent calling the
-    method multiple times.
     """
 
-    def update_ids(self, ids: set[_IdType]) -> None:
+    def update_ids(self, ids: set[_IdType], /) -> None:
         """Transform a source-to-ids mapping dict.
 
         Called just before IDs are fetched from the source.
@@ -29,7 +26,7 @@ class Transformer(_t.Protocol[_IdType]):
             ids: A collection of IDs from the `source`.
         """
 
-    def update_translations(self, translations: dict[_IdType, str]) -> None:
+    def update_translations(self, translations: dict[_IdType, str], /) -> None:
         """Transform a translations.
 
         Called by the :class:`.MagicDict` during initialization.
@@ -40,33 +37,19 @@ class Transformer(_t.Protocol[_IdType]):
 
     def try_add_missing_key(
         self,
-        key: _IdType,  # noqa: ARG002
+        key: _IdType,
         /,
         *,
-        translations: _t.MutableMapping[_IdType, str],  # noqa: ARG002
+        translations: _t.MutableMapping[_IdType, str],
     ) -> None:
         """Attempt to create and add a translation for an unknown ID.
 
-        Callback function used by :class:`.MagicDict` when unknown IDs are requested. Raise :class:`.TransformerStop` to
-        prevent calling this method.
+        Callback function used by :class:`.MagicDict` whenever an unknown ID is requested.
 
         Args:
             key: An ID which is not present in the `translations`.
             translations: A mutable mapping of translations. Typically, the :class:`.MagicDict` caller itself.
-
-        Raises:
-            TransformerStop: If this method should not be called (again).
         """
-        msg = f"not implemented: {type(self).__name__}.try_add_missing_key()"
-        raise TransformerStop(msg)
-
-
-class TransformerStop(Exception):  # noqa: N818
-    """Error indicating that this transformer method should not be called again.
-
-    Transformers may raise this exception at any point, after which the method of that instance will not be called again
-    by the caller which caught the exception.
-    """
 
 
 Transformers = dict[_SourceType, Transformer[_IdType]]

--- a/tests/dio/integration/test_dask.py
+++ b/tests/dio/integration/test_dask.py
@@ -19,7 +19,7 @@ def to_uuid(i: int) -> UUID:
 
 UNKNOWN = {"uuids": to_uuid(1000), "ints": 1000, "strs": "one thousand!"}
 EXPECTED = {
-    "uuids": ["00000001:uuid-one", "00000002:uuid-two", "<Failed: id=UUID('000003e8-0000-0000-0000-000000000000')>"],
+    "uuids": ["00000001:uuid-one", "00000002:uuid-two", "<Failed: id='000003e8-0000-0000-0000-000000000000'>"],
     "ints": ["0:int-zero", "1:int-one", "<Failed: id=1000>"],
     "strs": ["zero!:str-zero", "one!:str-one", "<Failed: id='one thousand!'>"],
 }

--- a/tests/dio/integration/test_polars.py
+++ b/tests/dio/integration/test_polars.py
@@ -18,7 +18,7 @@ def to_uuid(i: int) -> UUID:
 
 UNKNOWN = {"uuids": to_uuid(1000), "ints": 1000, "strs": "one thousand!"}
 EXPECTED = {
-    "uuids": ["00000001:uuid-one", "00000002:uuid-two", "<Failed: id=UUID('000003e8-0000-0000-0000-000000000000')>"],
+    "uuids": ["00000001:uuid-one", "00000002:uuid-two", "<Failed: id='000003e8-0000-0000-0000-000000000000'>"],
     "ints": ["0:int-zero", "1:int-one", "<Failed: id=1000>"],
     "strs": ["zero!:str-zero", "one!:str-one", "<Failed: id='one thousand!'>"],
 }
@@ -56,7 +56,8 @@ def test_dataframe(translator, df, copy):
         assert df.to_dict(as_series=False) == EXPECTED
 
 
-def test_series(translator, df):
-    for series in df.iter_columns():
-        actual: pl.Series = translator.translate(series)
-        assert actual.to_list() == EXPECTED[series.name]
+@pytest.mark.parametrize("column", [*UNKNOWN])
+def test_series(translator, df, column):
+    series = df[column]
+    actual: pl.Series = translator.translate(series)
+    assert actual.to_list() == EXPECTED[series.name]

--- a/tests/offline/test_magic_dict.py
+++ b/tests/offline/test_magic_dict.py
@@ -3,7 +3,7 @@ from uuid import UUID
 import pytest
 
 from id_translation.offline import MagicDict
-from id_translation.transform.types import Transformer, TransformerStop
+from id_translation.transform.types import Transformer
 
 
 def test_get(monkeypatch):
@@ -72,41 +72,37 @@ def test_transformer():
     assert subject[2] == "TWO"
     assert transformer.call_counts["try_add_missing_key"] == 1
     assert subject[2] == "TWO"
-    assert transformer.call_counts["try_add_missing_key"] == 1
+    assert transformer.call_counts["try_add_missing_key"] == 1  # hit - no increment
 
     assert subject[3] == "THREE"
     assert transformer.call_counts["try_add_missing_key"] == 2
     assert subject[3] == "THREE"
-    assert transformer.call_counts["try_add_missing_key"] == 2
+    assert transformer.call_counts["try_add_missing_key"] == 2  # hit - no increment
 
-    assert subject[4] == "<Failed: id=4>"
-    assert subject[5] == "<Failed: id=5>"
-    assert subject[6] == "<Failed: id=6>"
+    assert subject[4] == "<Failed: id=4>"  # 3rd miss
+    assert subject[4] == "<Failed: id=4>"  # 4th miss
+    assert subject[5] == "<Failed: id=5>"  # 5th miss
+    assert subject[4] == "<Failed: id=4>"  # 6th miss
+    assert subject[4] == "<Failed: id=4>"  # 7th miss
+    assert subject[6] == "<Failed: id=6>"  # 8thh miss
 
-    assert transformer.call_counts == {"update_translations": 1, "try_add_missing_key": DummyTransformer.max_try}
-    with pytest.raises(TransformerStop):
-        transformer.try_add_missing_key(-1, translations=subject)
+    assert transformer.call_counts == {"update_translations": 1, "try_add_missing_key": 8}
 
 
 class DummyTransformer(Transformer[int]):
-    max_try = 3
-
     def __init__(self):
         self.call_counts = {"update_translations": 0, "try_add_missing_key": 0}
 
-    def update_ids(self, ids):
-        pass
+    def update_ids(self, _, /):
+        raise AssertionError("called by Translator only")
 
-    def update_translations(self, translations):
+    def update_translations(self, translations, /):
         assert self.call_counts["update_translations"] == 0
         self.call_counts["update_translations"] = 1
         assert translations.get(-1) is None
 
     def try_add_missing_key(self, key, /, *, translations):
         self.call_counts["try_add_missing_key"] += 1
-
-        if self.call_counts["try_add_missing_key"] >= self.max_try:
-            raise TransformerStop()
 
         if (value := {2: "TWO", 3: "THREE"}.get(key)) is not None:
             translations[key] = value

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -299,6 +299,8 @@ def test_extra_placeholder():
         default_fmt="{id}:{right}",
         default_fmt_placeholders=dict(default={"left": "left-value", "right": "right-value"}),
     )
+    assert t.translate(1999, "people") == "1999:Sofia"
+
     assert t.translate(1, names="people") == "1:right-value"
 
     t = t.copy(default_fmt="{left}, {right}")
@@ -306,6 +308,9 @@ def test_extra_placeholder():
 
     t = t.copy(default_fmt_placeholders=dict(default={"left": "LEFT", "right": "RIGHT"}))
     assert t.translate(1, names="people") == "LEFT, RIGHT"
+
+    with pytest.raises(TooManyFailedTranslationsError):
+        t.translate(1, names="people", max_fails=0)
 
 
 def test_plain_default(hex_fetcher):

--- a/tests/transform/main.toml
+++ b/tests/transform/main.toml
@@ -4,6 +4,7 @@ fmt = "{name}"
 [transform.drinking_preferences_bitmask.BitmaskTransformer]
 joiner = " AND "
 overrides = [{ id = 0, override = "just water" }]
+force_real_translations = true
 
 [transform.guests.'tests.transform.test_factory.SayHi']
 random_seed = 2019

--- a/tests/transform/test_factory.py
+++ b/tests/transform/test_factory.py
@@ -42,10 +42,10 @@ class SayHi(Transformer[int]):
 
         self.random = Random(random_seed)
 
-    def update_ids(self, ids):
+    def update_ids(self, _, /):
         pass
 
-    def update_translations(self, translations):
+    def update_translations(self, translations, /):
         greetings = ["Oh, it's you again {}.", "Hello {}!", "What's up, {}?"]
 
         for idx, name in translations.items():


### PR DESCRIPTION
Similar to the caching rework, this simplifies the internal logic of the lib. Slowly working toward 1.0.0.

* Simplify the API so that I have one less thing to worry
* Remove `TransformerStop`-related logic. Convert args to pos-only.
* Fix `max_fails` crash with transformers that add new IDs (e.g. the `BitmaskTransformer`)
* Update `BitmaskTransformer`:
  * Don't use missing IDs to create composite translations by default
  * Revert to old behavior with by setting `force_real_translations=False` at init
 * Fix incorrect docs related to an old, weird interaction between `max_fails` and `default_fmt_placeholders`