### PR TITLE
benchmark/ci: provide click to the backfill runner

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -145,8 +145,8 @@ jobs:
 
       - name: Backfill history (isolated env per release)
         shell: bash
-        # The script only needs stdlib; it shells out to `uv run --isolated` per release.
-        run: uv run --no-project python benchmark/scripts/backfill.py --min "${{ github.event.inputs.backfill_min }}"
+        # The runner script needs only click (stdlib otherwise); it shells out to `uv run --isolated` per release.
+        run: uv run --no-project --with click python benchmark/scripts/backfill.py --min "${{ github.event.inputs.backfill_min }}"
 
       - name: Commit history
         shell: bash


### PR DESCRIPTION
The backfill workflow (`benchmark.yml`, `workflow_dispatch` with `backfill=true`) failed on its first real dispatch:

```
File ".../benchmark/scripts/backfill.py", line 21, in <module>
    import click
ModuleNotFoundError: No module named 'click'
```

**Cause:** the step runs `backfill.py` via `uv run --no-project`, and its comment claimed the script "only needs stdlib" — but the argparse→click migration made it import `click` at module level. With `--no-project`, no deps are installed, so it dies at import before reaching any release.

**Fix:** add `--with click` to the invocation (and correct the comment). The script is otherwise stdlib-only; the actual per-release work happens in isolated `uv run --isolated` envs it spawns.

Latent since the Click migration — only surfaced now because the backfill is dispatch-only and had never been triggered. Blocks the backfill run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)